### PR TITLE
Validate SSIDs when configuring WEP, password-less, and EAP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ vintage_net_wifi-*.tar
 
 # Don't put anything in the /priv directory. The Makefile "owns" it.
 /priv
+
+# Ignore temporary directory used for unit tests.
+/test_tmp

--- a/lib/vintage_net_wifi/wpa2.ex
+++ b/lib/vintage_net_wifi/wpa2.ex
@@ -107,7 +107,7 @@ defmodule VintageNetWiFi.WPA2 do
   @spec validate_ssid(String.t()) :: :ok | {:error, invalid_ssid_error()}
   def validate_ssid(ssid) when byte_size(ssid) == 0, do: {:error, :ssid_too_short}
   def validate_ssid(ssid) when byte_size(ssid) <= 32, do: :ok
-  def validate_ssid(_ssid), do: {:error, :ssid_too_long}
+  def validate_ssid(ssid) when is_binary(ssid), do: {:error, :ssid_too_long}
 
   defp all_ascii(<<c, rest::binary>>) when c >= 32 and c <= 126 do
     all_ascii(rest)

--- a/test/vintage_net_wifi_test.exs
+++ b/test/vintage_net_wifi_test.exs
@@ -30,7 +30,7 @@ defmodule VintageNetWiFiTest do
 
     assert capture_log(fn ->
              assert normalized_input == VintageNetWiFi.normalize(input)
-    end) =~ "deprecated"
+           end) =~ "deprecated"
   end
 
   test "old way of specifying ap mode works" do
@@ -182,6 +182,39 @@ defmodule VintageNetWiFiTest do
     }
 
     assert output == VintageNetWiFi.to_raw_config("wlan0", input, default_opts())
+  end
+
+  test "normalization raises on bad ssids and psks" do
+    # WPA2 PSK configs
+    assert_raise ArgumentError, fn ->
+      VintageNetWiFi.normalize(%{
+        type: VintageNetWiFi,
+        vintage_net_wifi: %{
+          networks: [
+            %{ssid: "123456789012345678901234567890123", psk: "supersecret", key_mgmt: :wpa_psk}
+          ]
+        }
+      })
+    end
+
+    # No security configs
+    assert_raise ArgumentError, fn ->
+      VintageNetWiFi.normalize(%{
+        type: VintageNetWiFi,
+        vintage_net_wifi: %{
+          networks: [%{ssid: "", key_mgmt: :none}]
+        }
+      })
+    end
+
+    assert_raise ArgumentError, fn ->
+      VintageNetWiFi.normalize(%{
+        type: VintageNetWiFi,
+        vintage_net_wifi: %{
+          networks: [%{ssid: "123456789012345678901234567890123", key_mgmt: :none}]
+        }
+      })
+    end
   end
 
   test "normalization converts passphrases to PSKs" do

--- a/test/vintage_net_wifi_test.exs
+++ b/test/vintage_net_wifi_test.exs
@@ -215,6 +215,16 @@ defmodule VintageNetWiFiTest do
         }
       })
     end
+
+    # Non-strings
+    assert_raise FunctionClauseError, fn ->
+      VintageNetWiFi.normalize(%{
+        type: VintageNetWiFi,
+        vintage_net_wifi: %{
+          networks: [%{ssid: 123, key_mgmt: :none}]
+        }
+      })
+    end
   end
 
   test "normalization converts passphrases to PSKs" do


### PR DESCRIPTION
They previously were only validated on WPA PSK configurations. This also
raises if someone passes an empty SSID.