### PR TITLE
Include `gateway` and `name_servers` in static IP example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,9 @@ iex> VintageNet.configure("wlan0", %{
       ipv4: %{
         method: :static,
         address: "192.168.24.1",
-        netmask: "255.255.255.0"
+        gateway: "192.168.24.255",
+        netmask: "255.255.255.0",
+        name_servers: ["1.1.1.1"]
       },
       dhcpd: %{
         start: "192.168.24.2",


### PR DESCRIPTION
This PR includes `gateway` and `name_servers` config for the static IP examples in the README. 
 Although the documentation defers to `VintageNet` configuration, I missed this, and after checking `VintageNet` it seems it's actually described within the "configuration cookbook", so surfacing it here seems like a good idea.