### PR TITLE
Remove _ = on all Logger calls

### DIFF
--- a/lib/vintage_net_wifi.ex
+++ b/lib/vintage_net_wifi.ex
@@ -112,10 +112,9 @@ defmodule VintageNetWiFi do
     # If user specified a standalone ssid, move it to the first spot
     # in the networks list so that networks are only stored in one place.
 
-    _ =
-      Logger.warn(
-        "Passing Wi-Fi network parameters outside of `:networks` for ssid '#{ssid}' is deprecated. See `VintageNet.info` for the fixed configuration."
-      )
+    Logger.warn(
+      "Passing Wi-Fi network parameters outside of `:networks` for ssid '#{ssid}' is deprecated. See `VintageNet.info` for the fixed configuration."
+    )
 
     # Rather than figure out which keys are relevant, move them all to
     # the first place in networks and let the network normalization code

--- a/lib/vintage_net_wifi/wpa_supplicant.ex
+++ b/lib/vintage_net_wifi/wpa_supplicant.ex
@@ -216,7 +216,7 @@ defmodule VintageNetWiFi.WPASupplicant do
         new_state
 
       _error ->
-        _ = Logger.warn("AP added and then removed before we could get info on it: #{bssid}")
+        Logger.warn("AP added and then removed before we could get info on it: #{bssid}")
         state
     end
   end
@@ -250,7 +250,7 @@ defmodule VintageNetWiFi.WPASupplicant do
   end
 
   defp handle_notification({:event, "CTRL-EVENT-CONNECTED", bssid, "completed", _}, state) do
-    _ = Logger.info("Connected to AP: #{bssid}")
+    Logger.info("Connected to AP: #{bssid}")
 
     case get_access_point_info(state.ll, bssid) do
       {:ok, ap} ->
@@ -259,8 +259,7 @@ defmodule VintageNetWiFi.WPASupplicant do
         new_state
 
       _error ->
-        _ =
-          Logger.warn("Connected and disconnected to AP before we could get info on it: #{bssid}")
+        Logger.warn("Connected and disconnected to AP before we could get info on it: #{bssid}")
 
         new_state = %{state | current_ap: nil}
         update_current_access_point_property(new_state)
@@ -269,14 +268,14 @@ defmodule VintageNetWiFi.WPASupplicant do
   end
 
   defp handle_notification({:event, "CTRL-EVENT-CONNECTED", bssid, status, _}, state) do
-    _ = Logger.warn("Unknown AP connection status: #{bssid} #{status}")
+    Logger.warn("Unknown AP connection status: #{bssid} #{status}")
     new_state = %{state | current_ap: nil}
     update_current_access_point_property(new_state)
     new_state
   end
 
   defp handle_notification({:event, "CTRL-EVENT-DISCONNECTED", bssid, _}, state) do
-    _ = Logger.warn("AP disconnected: #{bssid}")
+    Logger.warn("AP disconnected: #{bssid}")
     new_state = %{state | current_ap: nil}
     update_current_access_point_property(new_state)
     new_state
@@ -393,12 +392,12 @@ defmodule VintageNetWiFi.WPASupplicant do
   end
 
   defp handle_notification({:info, message}, state) do
-    _ = Logger.info("wpa_supplicant(#{state.ifname}): #{message}")
+    Logger.info("wpa_supplicant(#{state.ifname}): #{message}")
     state
   end
 
   defp handle_notification(unhandled, state) do
-    _ = Logger.info("WPASupplicant ignoring #{inspect(unhandled)}")
+    Logger.info("WPASupplicant ignoring #{inspect(unhandled)}")
     state
   end
 

--- a/lib/vintage_net_wifi/wpa_supplicant_ll.ex
+++ b/lib/vintage_net_wifi/wpa_supplicant_ll.ex
@@ -105,7 +105,7 @@ defmodule VintageNetWiFi.WPASupplicantLL do
     if pid do
       send(pid, {__MODULE__, priority - ?0, notification})
     else
-      _ = Logger.info("wpa_supplicant_ll dropping notification: #{notification}")
+      Logger.info("wpa_supplicant_ll dropping notification: #{notification}")
     end
 
     {:noreply, state}
@@ -115,7 +115,7 @@ defmodule VintageNetWiFi.WPASupplicantLL do
   def handle_info({:udp, socket, _, 0, response}, %{socket: socket} = state) do
     case List.pop_at(state.requests, 0) do
       {nil, _requests} ->
-        _ = Logger.warn("wpa_supplicant sent an unexpected message: '#{response}'")
+        Logger.warn("wpa_supplicant sent an unexpected message: '#{response}'")
         {:noreply, state}
 
       {from, new_requests} ->


### PR DESCRIPTION
Elixir 1.10's Logger calls only return :ok now, so the return value no
longer needs to be ignored to make Dialyzer happy.