### PR TITLE
Replace outdated terminology

### DIFF
--- a/lib/vintage_net_wifi.ex
+++ b/lib/vintage_net_wifi.ex
@@ -14,8 +14,8 @@ defmodule VintageNetWiFi do
     :key_mgmt,
     :ssid,
     :bssid,
-    :bssid_whitelist,
-    :bssid_blacklist,
+    :bssid_allowlist,
+    :bssid_denylist,
     :priority,
     :scan_ssid,
     :frequency
@@ -356,8 +356,8 @@ defmodule VintageNetWiFi do
       into_config_string(wifi, :key_mgmt),
       into_config_string(wifi, :scan_ssid),
       into_config_string(wifi, :priority),
-      into_config_string(wifi, :bssid_whitelist),
-      into_config_string(wifi, :bssid_blacklist),
+      into_config_string(wifi, :bssid_allowlist),
+      into_config_string(wifi, :bssid_denylist),
       into_config_string(wifi, :wps_disabled),
       into_config_string(wifi, :mode),
       into_config_string(wifi, :frequency),
@@ -565,11 +565,11 @@ defmodule VintageNetWiFi do
     "pcsc=#{inspect(value)}"
   end
 
-  defp wifi_opt_to_config_string(_wifi, :bssid_blacklist, value) do
+  defp wifi_opt_to_config_string(_wifi, :bssid_denylist, value) do
     "bssid_blacklist=#{value}"
   end
 
-  defp wifi_opt_to_config_string(_wifi, :bssid_whitelist, value) do
+  defp wifi_opt_to_config_string(_wifi, :bssid_allowlist, value) do
     "bssid_whitelist=#{value}"
   end
 

--- a/test/vintage_net_wifi_test.exs
+++ b/test/vintage_net_wifi_test.exs
@@ -1310,7 +1310,7 @@ defmodule VintageNetWiFiTest do
     assert output == VintageNetWiFi.to_raw_config("wlan0", input, default_opts())
   end
 
-  test "configuration blacklisting two APs" do
+  test "configuration denying two APs" do
     input = %{
       type: VintageNetWiFi,
       vintage_net_wifi: %{
@@ -1319,7 +1319,7 @@ defmodule VintageNetWiFiTest do
             ssid: "example",
             key_mgmt: :wpa_psk,
             psk: "very secret passphrase",
-            bssid_blacklist: "02:11:22:33:44:55 02:22:aa:44:55:66"
+            bssid_denylist: "02:11:22:33:44:55 02:22:aa:44:55:66"
           }
         ]
       },
@@ -1380,7 +1380,7 @@ defmodule VintageNetWiFiTest do
             ssid: "example",
             key_mgmt: :wpa_psk,
             psk: "very secret passphrase",
-            bssid_whitelist:
+            bssid_allowlist:
               "02:55:ae:bc:00:00/ff:ff:ff:ff:00:00 00:00:77:66:55:44/00:00:ff:ff:ff:ff"
           }
         ]

--- a/test/wifi_compatibility_test.exs
+++ b/test/wifi_compatibility_test.exs
@@ -1276,7 +1276,7 @@ defmodule WiFiCompatibilityTest do
     assert output == VintageNet.Technology.WiFi.to_raw_config("wlan0", input, default_opts())
   end
 
-  test "configuration blacklisting two APs" do
+  test "configuration denying two APs" do
     input = %{
       type: VintageNet.Technology.WiFi,
       wifi: %{
@@ -1285,7 +1285,7 @@ defmodule WiFiCompatibilityTest do
             ssid: "example",
             key_mgmt: :wpa_psk,
             psk: "very secret passphrase",
-            bssid_blacklist: "02:11:22:33:44:55 02:22:aa:44:55:66"
+            bssid_denylist: "02:11:22:33:44:55 02:22:aa:44:55:66"
           }
         ]
       },
@@ -1346,7 +1346,7 @@ defmodule WiFiCompatibilityTest do
             ssid: "example",
             key_mgmt: :wpa_psk,
             psk: "very secret passphrase",
-            bssid_whitelist:
+            bssid_allowlist:
               "02:55:ae:bc:00:00/ff:ff:ff:ff:00:00 00:00:77:66:55:44/00:00:ff:ff:ff:ff"
           }
         ]


### PR DESCRIPTION
This is a breaking change, but BSSID filtering is not documented in
vintage_net_wifi and probably not used yet.