### PR TITLE
Add quick configure and cookbook helper functions

### DIFF
--- a/lib/vintage_net_wifi/cookbook.ex
+++ b/lib/vintage_net_wifi/cookbook.ex
@@ -1,0 +1,135 @@
+defmodule VintageNetWiFi.Cookbook do
+  @moduledoc """
+  Recipes for common WiFi network configurations
+
+  For example, if you want the standard configuration for the most common type of WiFi
+  network (WPA2 Preshared Key networks), pass the SSID and password to `wpa_psk/2`
+  """
+
+  alias VintageNetWiFi.WPA2
+
+  @doc """
+  Return a configuration for connecting to open WiFi network
+
+  Pass an SSID and passphrase. If the SSID and passphrase are ok, you'll get an
+  `:ok` tuple with the configuration. If there's a problem, you'll get an error
+  tuple with a reason.
+  """
+  @spec open_wifi(String.t()) :: {:ok, map()} | {:error, WPA2.invalid_ssid_error()}
+  def open_wifi(ssid) when is_binary(ssid) do
+    with :ok <- WPA2.validate_ssid(ssid) do
+      {:ok,
+       %{
+         type: VintageNetWiFi,
+         vintage_net_wifi: %{
+           networks: [
+             %{
+               key_mgmt: :none,
+               ssid: ssid
+             }
+           ]
+         },
+         ipv4: %{method: :dhcp}
+       }}
+    end
+  end
+
+  @doc """
+  Return a configuration for connecting to a WPA-PSK network
+
+  Pass an SSID and passphrase. If the SSID and passphrase are ok, you'll get an
+  `:ok` tuple with the configuration. If there's a problem, you'll get an error
+  tuple with a reason.
+  """
+  @spec wpa_psk(String.t(), String.t()) ::
+          {:ok, map()} | {:error, WPA2.invalid_ssid_error() | WPA2.invalid_passphrase_error()}
+  def wpa_psk(ssid, passphrase) when is_binary(ssid) and is_binary(passphrase) do
+    with :ok <- WPA2.validate_ssid(ssid),
+         :ok <- WPA2.validate_passphrase(passphrase) do
+      {:ok,
+       %{
+         type: VintageNetWiFi,
+         vintage_net_wifi: %{
+           networks: [
+             %{
+               key_mgmt: :wpa_psk,
+               ssid: ssid,
+               psk: passphrase
+             }
+           ]
+         },
+         ipv4: %{method: :dhcp}
+       }}
+    end
+  end
+
+  @doc """
+  Return a configuration for connecting to a WPA-EAP PEAP network
+
+  Pass an SSID and login credentials. If valid, you'll get an
+  `:ok` tuple with the configuration. If there's a problem, you'll get an error
+  tuple with a reason.
+  """
+  @spec wpa_eap_peap(String.t(), String.t(), String.t()) ::
+          {:ok, map()} | {:error, WPA2.invalid_ssid_error()}
+  def wpa_eap_peap(ssid, username, passphrase)
+      when is_binary(ssid) and is_binary(username) and is_binary(passphrase) do
+    with :ok <- WPA2.validate_ssid(ssid) do
+      {:ok,
+       %{
+         type: VintageNetWiFi,
+         vintage_net_wifi: %{
+           networks: [
+             %{
+               key_mgmt: :wpa_eap,
+               ssid: ssid,
+               identity: username,
+               password: passphrase,
+               eap: "PEAP",
+               phase2: "auth=MSCHAPV2"
+             }
+           ]
+         },
+         ipv4: %{method: :dhcp}
+       }}
+    end
+  end
+
+  @doc """
+  Return a configuration for creating an open access point
+
+  Pass an SSID and an optional IPv4 class C network.
+  """
+  @spec open_access_point(String.t(), VintageNet.any_ip_address()) ::
+          {:ok, map()} | {:error, term()}
+  def open_access_point(ssid, ipv4_subnet \\ "192.168.24.0") do
+    with :ok <- WPA2.validate_ssid(ssid),
+         {:ok, {a, b, c, _d}} <- VintageNet.IP.ip_to_tuple(ipv4_subnet),
+         our_address = {a, b, c, 1},
+         dhcp_start = {a, b, c, 10},
+         dhcp_end = {a, b, c, 250} do
+      {:ok,
+       %{
+         type: VintageNetWiFi,
+         vintage_net_wifi: %{
+           networks: [
+             %{
+               mode: :ap,
+               ssid: ssid,
+               key_mgmt: :none
+             }
+           ]
+         },
+         ipv4: %{
+           method: :static,
+           address: our_address,
+           netmask: {255, 255, 255, 0}
+         },
+         dhcpd: %{
+           start: dhcp_start,
+           end: dhcp_end
+         }
+       }}
+    end
+  end
+end

--- a/test/vintage_net_wifi/cookbook_test.exs
+++ b/test/vintage_net_wifi/cookbook_test.exs
@@ -1,0 +1,65 @@
+defmodule VintageNetWiFi.CookbookTest do
+  use ExUnit.Case
+
+  alias VintageNetWiFi.Cookbook
+
+  test "open_wifi/2" do
+    assert {:ok,
+            %{
+              type: VintageNetWiFi,
+              ipv4: %{method: :dhcp},
+              vintage_net_wifi: %{networks: [%{key_mgmt: :none, ssid: "free_wifi"}]}
+            }} == Cookbook.open_wifi("free_wifi")
+
+    assert {:error, :ssid_too_short} == Cookbook.open_wifi("")
+  end
+
+  test "wpa_psk/2" do
+    assert {:ok,
+            %{
+              type: VintageNetWiFi,
+              ipv4: %{method: :dhcp},
+              vintage_net_wifi: %{
+                networks: [%{key_mgmt: :wpa_psk, psk: "my_passphrase", ssid: "my_ssid"}]
+              }
+            }} == Cookbook.wpa_psk("my_ssid", "my_passphrase")
+  end
+
+  test "wpa_eap_peap/2" do
+    assert {:ok,
+            %{
+              type: VintageNetWiFi,
+              ipv4: %{method: :dhcp},
+              vintage_net_wifi: %{
+                networks: [
+                  %{
+                    key_mgmt: :wpa_eap,
+                    ssid: "corp_wifi",
+                    eap: "PEAP",
+                    identity: "username",
+                    password: "password",
+                    phase2: "auth=MSCHAPV2"
+                  }
+                ]
+              }
+            }} == Cookbook.wpa_eap_peap("corp_wifi", "username", "password")
+  end
+
+  test "open_access_point/2" do
+    assert {:ok,
+            %{
+              type: VintageNetWiFi,
+              ipv4: %{address: {192, 168, 24, 1}, method: :static, netmask: {255, 255, 255, 0}},
+              dhcpd: %{end: {192, 168, 24, 250}, start: {192, 168, 24, 10}},
+              vintage_net_wifi: %{networks: [%{key_mgmt: :none, mode: :ap, ssid: "my_network"}]}
+            }} == Cookbook.open_access_point("my_network")
+
+    assert {:ok,
+            %{
+              type: VintageNetWiFi,
+              ipv4: %{address: {10, 1, 2, 1}, method: :static, netmask: {255, 255, 255, 0}},
+              dhcpd: %{end: {10, 1, 2, 250}, start: {10, 1, 2, 10}},
+              vintage_net_wifi: %{networks: [%{key_mgmt: :none, mode: :ap, ssid: "another_net"}]}
+            }} == Cookbook.open_access_point("another_net", "10.1.2.3")
+  end
+end


### PR DESCRIPTION
The goal for these helpers is to lower the friction to configuring the most common types of networks. There are two interfaces:

1. `VintageNetWiFi.quick_configure` for configuring WiFi on `"wlan0"` to either an open WiFi configuration or a WPA-PSK2 one
2. `VintageNetWiFi.Cookbook` for a set of helper functions for coming up with the configurations to pass to `VintageNet.configure/2`

My hope is that users will do this at the `iex` prompt:

```elixir
iex> VintageNetWiFi.quick_configure("my_access_point_name", "password")
```

and then wait a bit and then their device will be connected. The `quick_configure` functions only work for WPA2 PSK and open networks, but that's probably 90+% of what people have.

The next step is to help make the configurations. That's what `VintageNetWiFi.Cookbook` is for and these configurations could be used anywhere. For example, these functions could help make hardcoded configs in the `config.exs` or they could be used in people's programs to avoid dealing with the configuration maps.

The `quick_configure` functions use the `VintageNetWiFi.Cookbook`.