### PR TITLE
Automatically subscribe to wpa_supplicant notifications

### DIFF
--- a/lib/vintage_net_wifi/wpa_supplicant.ex
+++ b/lib/vintage_net_wifi/wpa_supplicant.ex
@@ -115,8 +115,9 @@ defmodule VintageNetWiFi.WPASupplicant do
     primary_path =
       case wait_for_control_file(control_paths) do
         [primary_path, secondary_path] ->
-          {:ok, secondary_ll} = WPASupplicantLL.start_link(secondary_path)
-          :ok = WPASupplicantLL.subscribe(secondary_ll)
+          {:ok, secondary_ll} =
+            WPASupplicantLL.start_link(path: secondary_path, notification_pid: self())
+
           {:ok, "OK\n"} = WPASupplicantLL.control_request(secondary_ll, "ATTACH")
           primary_path
 
@@ -128,8 +129,7 @@ defmodule VintageNetWiFi.WPASupplicant do
                 "Couldn't find wpa_supplicant control files: #{inspect(control_paths)}"
       end
 
-    {:ok, ll} = WPASupplicantLL.start_link(primary_path)
-    :ok = WPASupplicantLL.subscribe(ll)
+    {:ok, ll} = WPASupplicantLL.start_link(path: primary_path, notification_pid: self())
     {:ok, "OK\n"} = WPASupplicantLL.control_request(ll, "ATTACH")
 
     # Refresh the AP list

--- a/test/vintage_net_wifi/wpa_supplicant_ll_test.exs
+++ b/test/vintage_net_wifi/wpa_supplicant_ll_test.exs
@@ -18,8 +18,7 @@ defmodule VintageNetWiFi.WPASupplicantLLTest do
   end
 
   test "receives notifications", context do
-    ll = start_supervised!({WPASupplicantLL, context.socket_path})
-    :ok = WPASupplicantLL.subscribe(ll, self())
+    start_supervised!({WPASupplicantLL, path: context.socket_path, notification_pid: self()})
 
     MockWPASupplicant.send_message(context.mock, "<1>Hello")
     MockWPASupplicant.send_message(context.mock, "<2>Goodbye")
@@ -29,8 +28,7 @@ defmodule VintageNetWiFi.WPASupplicantLLTest do
   end
 
   test "responds to requests", context do
-    ll = start_supervised!({WPASupplicantLL, context.socket_path})
-    :ok = WPASupplicantLL.subscribe(ll, self())
+    ll = start_supervised!({WPASupplicantLL, path: context.socket_path, notification_pid: self()})
 
     MockWPASupplicant.set_responses(context.mock, %{"SCAN" => "OK"})
 
@@ -40,8 +38,8 @@ defmodule VintageNetWiFi.WPASupplicantLLTest do
   test "ignores unexpected responses", context do
     # capture_log hides the "log message from WPASupplicantLL when it sees an unexpected message"
     capture_log(fn ->
-      ll = start_supervised!({WPASupplicantLL, context.socket_path})
-      :ok = WPASupplicantLL.subscribe(ll, self())
+      ll =
+        start_supervised!({WPASupplicantLL, path: context.socket_path, notification_pid: self()})
 
       MockWPASupplicant.send_message(context.mock, "Bad response")
 
@@ -54,8 +52,7 @@ defmodule VintageNetWiFi.WPASupplicantLLTest do
   end
 
   test "handles notifications while waiting for a response", context do
-    ll = start_supervised!({WPASupplicantLL, context.socket_path})
-    :ok = WPASupplicantLL.subscribe(ll, self())
+    ll = start_supervised!({WPASupplicantLL, path: context.socket_path, notification_pid: self()})
 
     MockWPASupplicant.set_responses(context.mock, %{"SCAN" => ["<1>Notification", "OK"]})
 
@@ -65,8 +62,7 @@ defmodule VintageNetWiFi.WPASupplicantLLTest do
   end
 
   test "multiple requests outstanding", context do
-    ll = start_supervised!({WPASupplicantLL, context.socket_path})
-    :ok = WPASupplicantLL.subscribe(ll, self())
+    ll = start_supervised!({WPASupplicantLL, path: context.socket_path, notification_pid: self()})
 
     # Set up the responses so that REQUEST1 has to wait for REQUEST2
     # to be sent before it gets a response


### PR DESCRIPTION
This removes the need to call WPASupplicant_LL.subscribe/2 after
starting the GenServer. This doesn't fix any known issues. It just
deletes code and a possible source of bugs.
