### PR TITLE
Handle missing AP flags more gracefully

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ install_system_deps: &install_system_deps
 jobs:
   build_elixir_1_11_otp_23:
     docker:
-      - image: hexpm/elixir:1.11.4-erlang-23.3-alpine-3.13.2
+      - image: hexpm/elixir:1.11.4-erlang-23.3.1-alpine-3.13.3
     <<: *defaults
     steps:
       - checkout
@@ -46,7 +46,7 @@ jobs:
 
   build_elixir_1_10_otp_23:
     docker:
-      - image: hexpm/elixir:1.10.4-erlang-23.3-alpine-3.13.2
+      - image: hexpm/elixir:1.10.4-erlang-23.3.1-alpine-3.13.3
     <<: *defaults
     steps:
       - checkout
@@ -58,7 +58,7 @@ jobs:
 
   build_elixir_1_9_otp_22:
     docker:
-      - image: hexpm/elixir:1.9.4-erlang-22.3.4.9-alpine-3.13.1
+      - image: hexpm/elixir:1.9.4-erlang-22.3.4.17-alpine-3.13.3
     <<: *defaults
     steps:
       - checkout
@@ -70,7 +70,7 @@ jobs:
 
   build_elixir_1_8_otp_22:
     docker:
-      - image: hexpm/elixir:1.8.2-erlang-22.3.4.9-alpine-3.13.1
+      - image: hexpm/elixir:1.8.2-erlang-22.3.4.17-alpine-3.13.3
     <<: *defaults
     steps:
       - checkout
@@ -82,7 +82,7 @@ jobs:
 
   build_elixir_1_7_otp_21:
     docker:
-      - image: hexpm/elixir:1.7.4-erlang-21.3.8.15-alpine-3.12.0
+      - image: hexpm/elixir:1.7.4-erlang-21.3.8.22-alpine-3.13.3
     <<: *defaults
     steps:
       - checkout

--- a/lib/vintage_net_wifi/wpa_supplicant_decoder.ex
+++ b/lib/vintage_net_wifi/wpa_supplicant_decoder.ex
@@ -245,12 +245,14 @@ defmodule VintageNetWiFi.WPASupplicantDecoder do
   @doc """
   Parse WiFi access point flags
   """
-  @spec parse_flags(String.t()) :: [VintageNetWiFi.AccessPoint.flag()]
-  def parse_flags(flags) do
+  @spec parse_flags(String.t() | nil) :: [VintageNetWiFi.AccessPoint.flag()]
+  def parse_flags(flags) when is_binary(flags) do
     flags
     |> String.split(["]", "["], trim: true)
     |> Enum.flat_map(&parse_flag/1)
   end
+
+  def parse_flags(nil), do: []
 
   defp parse_flag("WPA2-PSK-CCMP"), do: [:wpa2_psk_ccmp]
   defp parse_flag("WPA2-EAP-CCMP"), do: [:wpa2_eap_ccmp]

--- a/test/vintage_net_wifi/wpa_supplicant_decoder_test.exs
+++ b/test/vintage_net_wifi/wpa_supplicant_decoder_test.exs
@@ -496,6 +496,10 @@ defmodule VintageNetWiFi.WPASupplicantDecoderTest do
     assert [:wpa_eap_ccmp_tkip] = WPASupplicantDecoder.parse_flags("[WPA-EAP-CCMP+TKIP]")
 
     assert [] = WPASupplicantDecoder.parse_flags("[something random]")
+
+    # Missing flags were noticed once even though this doesn't seem like it should
+    # happen. Don't crash, though.
+    assert [] == WPASupplicantDecoder.parse_flags(nil)
   end
 
   test "decodes eap cert" do


### PR DESCRIPTION
This fixes a crash. Everything recovered, but it seems harsh to crash on
a missing flags field from wpa_supplicant. This bulletproofs the code.
