### PR TITLE
Time out dropped requests rather than crashing

### DIFF
--- a/test/support/mock_wpa_supplicant.ex
+++ b/test/support/mock_wpa_supplicant.ex
@@ -79,9 +79,13 @@ defmodule VintageNetWiFiTest.MockWPASupplicant do
   end
 
   defp lookup(responses, message) do
-    case Map.get(responses, message, "Mock doesn't know about #{message}") do
-      list when is_list(list) -> list
-      other -> [other]
+    case Map.fetch(responses, message) do
+      {:ok, response} ->
+        List.wrap(response)
+
+      :error ->
+        raise RuntimeError,
+              "No canned response for #{message}. If this is to be ignored, set the response to []"
     end
   end
 end

--- a/test/vintage_net_wifi/wpa_supplicant_ll_test.exs
+++ b/test/vintage_net_wifi/wpa_supplicant_ll_test.exs
@@ -89,4 +89,12 @@ defmodule VintageNetWiFi.WPASupplicantLLTest do
       assert_receive ^expected, 5_000
     end
   end
+
+  test "requests timeouts", context do
+    ll = start_supervised!({WPASupplicantLL, path: context.socket_path, notification_pid: self()})
+
+    MockWPASupplicant.set_responses(context.mock, %{"Hello!" => []})
+
+    assert {:error, :timeout} == WPASupplicantLL.control_request(ll, "Hello!")
+  end
 end

--- a/test/vintage_net_wifi/wpa_supplicant_test.exs
+++ b/test/vintage_net_wifi/wpa_supplicant_test.exs
@@ -23,7 +23,7 @@ defmodule VintageNetWiFi.WPASupplicantTest do
   end
 
   test "attaches to wpa_supplicant", context do
-    MockWPASupplicant.set_responses(context.mock, %{"ATTACH" => ["OK\n"]})
+    MockWPASupplicant.set_responses(context.mock, %{"ATTACH" => "OK\n", "BSS 0" => ""})
 
     _ =
       start_supervised!(
@@ -41,7 +41,11 @@ defmodule VintageNetWiFi.WPASupplicantTest do
   end
 
   test "pings wpa_supplicant", context do
-    MockWPASupplicant.set_responses(context.mock, %{"ATTACH" => "OK\n", "PING" => "PONG\n"})
+    MockWPASupplicant.set_responses(context.mock, %{
+      "ATTACH" => "OK\n",
+      "PING" => "PONG\n",
+      "BSS 0" => ""
+    })
 
     _ =
       start_supervised!(
@@ -107,12 +111,14 @@ defmodule VintageNetWiFi.WPASupplicantTest do
   test "ap-mode station connect updates property", context do
     MockWPASupplicant.set_responses(context.mock, %{
       "ATTACH" => "OK\n",
-      "PING" => "PONG\n"
+      "PING" => "PONG\n",
+      "BSS 0" => ""
     })
 
     MockWPASupplicant.set_responses(context.p2p_dev_mock, %{
       "ATTACH" => "OK\n",
-      "PING" => "PONG\n"
+      "PING" => "PONG\n",
+      "BSS 0" => ""
     })
 
     clients_property = ["interface", "test_wlan0", "wifi", "clients"]
@@ -149,6 +155,7 @@ defmodule VintageNetWiFi.WPASupplicantTest do
     MockWPASupplicant.set_responses(context.mock, %{
       "ATTACH" => "OK\n",
       "PING" => "PONG\n",
+      "BSS 0" => "",
       "SCAN" => ["FAIL-BUSY  \n"]
     })
 
@@ -169,6 +176,7 @@ defmodule VintageNetWiFi.WPASupplicantTest do
     MockWPASupplicant.set_responses(context.mock, %{
       "ATTACH" => "OK\n",
       "PING" => "PONG\n",
+      "BSS 0" => "",
       "SCAN" => [
         "OK\n",
         "<2>CTRL-EVENT-SCAN-STARTED ",
@@ -210,6 +218,7 @@ defmodule VintageNetWiFi.WPASupplicantTest do
     MockWPASupplicant.set_responses(context.mock, %{
       "ATTACH" => "OK\n",
       "PING" => "PONG\n",
+      "BSS 0" => "",
       "SCAN" => [
         "OK\n",
         "<2>CTRL-EVENT-SCAN-STARTED ",
@@ -259,6 +268,7 @@ defmodule VintageNetWiFi.WPASupplicantTest do
     MockWPASupplicant.set_responses(context.mock, %{
       "ATTACH" => "OK\n",
       "PING" => "PONG\n",
+      "BSS 0" => "",
       "BSS 78:8a:20:87:7a:50" =>
         "id=0\nbssid=78:8a:20:87:7a:50\nfreq=2437\nbeacon_int=100\ncapabilities=0x0431\nqual=0\nnoise=-89\nlevel=-71\ntsf=0000333220048880\nage=14\nie=0008426f7062654c414e010882848b968c1298240301062a01003204b048606c0b0504000a00002d1aac011bffffff00000000000000000001000000000000000000003d1606080c000000000000000000000000000000000000007f080000000000000040dd180050f2020101000003a4000027a4000042435e0062322f00dd0900037f01010000ff7fdd1300156d00010100010237e58106788a20867a5030140100000fac040100000fac040100000fac020000\nflags=[WPA-EAP-CCMP+TKIP][ESS]\nssid=TestLAN\nsnr=18\nest_throughput=48000\nupdate_idx=1\nbeacon_ie=0008426f7062654c414e010882848b968c1298240301060504010300002a01003204b048606c0b0504000a00002d1aac011bffffff00000000000000000001000000000000000000003d1606080c000000000000000000000000000000000000007f080000000000000040dd180050f2020101000003a4000027a4000042435e0062322f00dd0900037f01010000ff7fdd1300156d00010100010237e58106788a20867a5030140100000fac040100000fac040100000fac020000\n"
     })
@@ -326,8 +336,10 @@ defmodule VintageNetWiFi.WPASupplicantTest do
     MockWPASupplicant.set_responses(context.mock, %{
       "ATTACH" => "OK\n",
       "PING" => "PONG\n",
+      "BSS 0" => "",
       "BSS 78:8a:20:87:7a:50" =>
-        "id=0\nbssid=78:8a:20:87:7a:50\nfreq=2437\nbeacon_int=100\ncapabilities=0x0431\nqual=0\nnoise=-89\nlevel=-71\ntsf=0000333220048880\nage=14\nie=0008426f7062654c414e010882848b968c1298240301062a01003204b048606c0b0504000a00002d1aac011bffffff00000000000000000001000000000000000000003d1606080c000000000000000000000000000000000000007f080000000000000040dd180050f2020101000003a4000027a4000042435e0062322f00dd0900037f01010000ff7fdd1300156d00010100010237e58106788a20867a5030140100000fac040100000fac040100000fac020000\nflags=[WPA2-PSK-CCMP][ESS]\nssid=TestLAN\nsnr=18\nest_throughput=48000\nupdate_idx=1\nbeacon_ie=0008426f7062654c414e010882848b968c1298240301060504010300002a01003204b048606c0b0504000a00002d1aac011bffffff00000000000000000001000000000000000000003d1606080c000000000000000000000000000000000000007f080000000000000040dd180050f2020101000003a4000027a4000042435e0062322f00dd0900037f01010000ff7fdd1300156d00010100010237e58106788a20867a5030140100000fac040100000fac040100000fac020000\n"
+        "id=0\nbssid=78:8a:20:87:7a:50\nfreq=2437\nbeacon_int=100\ncapabilities=0x0431\nqual=0\nnoise=-89\nlevel=-71\ntsf=0000333220048880\nage=14\nie=0008426f7062654c414e010882848b968c1298240301062a01003204b048606c0b0504000a00002d1aac011bffffff00000000000000000001000000000000000000003d1606080c000000000000000000000000000000000000007f080000000000000040dd180050f2020101000003a4000027a4000042435e0062322f00dd0900037f01010000ff7fdd1300156d00010100010237e58106788a20867a5030140100000fac040100000fac040100000fac020000\nflags=[WPA2-PSK-CCMP][ESS]\nssid=TestLAN\nsnr=18\nest_throughput=48000\nupdate_idx=1\nbeacon_ie=0008426f7062654c414e010882848b968c1298240301060504010300002a01003204b048606c0b0504000a00002d1aac011bffffff00000000000000000001000000000000000000003d1606080c000000000000000000000000000000000000007f080000000000000040dd180050f2020101000003a4000027a4000042435e0062322f00dd0900037f01010000ff7fdd1300156d00010100010237e58106788a20867a5030140100000fac040100000fac040100000fac020000\n",
+      "BSS 11:22:33:44:55:66" => ""
     })
 
     _supplicant =
@@ -402,6 +414,7 @@ defmodule VintageNetWiFi.WPASupplicantTest do
     MockWPASupplicant.set_responses(context.mock, %{
       "ATTACH" => "OK\n",
       "PING" => "PONG\n",
+      "BSS 0" => "",
       "SIGNAL_POLL" =>
         "RSSI=-32\nLINKSPEED=300\nNOISE=9999\nFREQUENCY=2472\nWIDTH=40 MHz\nCENTER_FRQ1=2462\n"
     })
@@ -432,6 +445,7 @@ defmodule VintageNetWiFi.WPASupplicantTest do
     MockWPASupplicant.set_responses(context.mock, %{
       "ATTACH" => "OK\n",
       "PING" => "PONG\n",
+      "BSS 0" => "",
       "SIGNAL_POLL" => "FAIL\n"
     })
 
@@ -451,8 +465,10 @@ defmodule VintageNetWiFi.WPASupplicantTest do
     MockWPASupplicant.set_responses(context.mock, %{
       "ATTACH" => "OK\n",
       "PING" => "PONG\n",
+      "BSS 0" => "",
       "BSS f8:a2:d6:b5:d4:07" =>
-        "id=7\nbssid=f8:a2:d6:b5:d4:07\nfreq=2432\nbeacon_int=1000\ncapabilities=0x0000\nqual=0\nnoise=-89\nlevel=-27\ntsf=0000005463796281\nage=2339\nie=0000010882848b968c1298240301053204b048606c2d1a7e0112ff000000010000000000000001000000000000000000003d16050000000000ff00000001000000000000000000000072076d792d6d657368710701010001000209\nflags=[MESH]\nssid=my-mesh\nmesh_id=my-mesh\nactive_path_selection_protocol_id=0x01\nactive_path_selection_metric_id=0x01\ncongestion_control_mode_id=0x00\nsynchronization_method_id=0x01\nauthentication_protocol_id=0x00\nmesh_formation_info=0x02\nmesh_capability=0x09\nbss_basic_rate_set=10 20 55 110 60 120 240\nsnr=62\nest_throughput=65000\nupdate_idx=2\n"
+        "id=7\nbssid=f8:a2:d6:b5:d4:07\nfreq=2432\nbeacon_int=1000\ncapabilities=0x0000\nqual=0\nnoise=-89\nlevel=-27\ntsf=0000005463796281\nage=2339\nie=0000010882848b968c1298240301053204b048606c2d1a7e0112ff000000010000000000000001000000000000000000003d16050000000000ff00000001000000000000000000000072076d792d6d657368710701010001000209\nflags=[MESH]\nssid=my-mesh\nmesh_id=my-mesh\nactive_path_selection_protocol_id=0x01\nactive_path_selection_metric_id=0x01\ncongestion_control_mode_id=0x00\nsynchronization_method_id=0x01\nauthentication_protocol_id=0x00\nmesh_formation_info=0x02\nmesh_capability=0x09\nbss_basic_rate_set=10 20 55 110 60 120 240\nsnr=62\nest_throughput=65000\nupdate_idx=2\n",
+      "BSS 00:0f:00:cf:e3:df" => ""
     })
 
     peers_property = ["interface", "test_wlan0", "wifi", "peers"]


### PR DESCRIPTION
This series of commits addresses a crash that looks like this:

```
14:07:03.540 [error] GenServer {VintageNet.Interface.Registry, {VintageNetWiFi.WPASupplicant, "wlan0"}} terminating
** (stop) exited in: GenServer.call(#PID<0.1515.0>, {:control_request, "BSS 0"}, 5000)
    ** (EXIT) time out
    (elixir 1.11.4) lib/gen_server.ex:1027: GenServer.call/3
    (vintage_net_wifi 0.9.2) lib/vintage_net_wifi/wpa_supplicant.ex:483: VintageNetWiFi.WPASupplicant.get_access_point_info/2
    (vintage_net_wifi 0.9.2) lib/vintage_net_wifi/wpa_supplicant.ex:209: VintageNetWiFi.WPASupplicant.handle_notification/2
    (vintage_net_wifi 0.9.2) lib/vintage_net_wifi/wpa_supplicant.ex:194: VintageNetWiFi.WPASupplicant.handle_info/2
    (stdlib 3.14) gen_server.erl:689: :gen_server.try_dispatch/4
    (stdlib 3.14) gen_server.erl:765: :gen_server.handle_msg/6
    (stdlib 3.14) proc_lib.erl:226: :proc_lib.init_p_do_apply/3
Last message: {VintageNetWiFi.WPASupplicantLL, 3, "CTRL-EVENT-BSS-ADDED 0 f6:92:bf:ad:69:d5"}
State: %{access_points: %{}, ap_mode: false, clients: [], control_dir: "/tmp/vintage_net/wpa_supplicant", current_ap: nil, eap_status: %VintageNet.Interface.EAPStatus{method: nil, remote_certificate_verified?: false, status: nil, timestamp: nil}, ifname: "wlan0", keep_alive_interval: 60000, ll: #PID<0.1515.0>, peers: [], verbose: false, wpa_supplicant: "wpa_supplicant", wpa_supplicant_conf_path: "/tmp/vintage_net/wpa_supplicant.conf.wlan0"}
```

Thanks for supervision, the system always recovers. However, the recovery will
cause VintageNet to report WiFi bouncing offline and then back and that causes
confusion downstream.

This issue is most easily reproduced when you're surrounded by a lot of WiFi
access points and then you deconfigure and reconfigure `wlan0`. It can also be
reproduced by scanning for access points and then connecting to one.

What happens is that the `wpa_supplicant` reports a flurry of BSSIDs that are in
range. `VintageNetWiFi` turns around and asks the `wpa_supplicant` to send more
information on each BSSID so that it can include that in the access point list.
When connecting to an access point, the `wpa_supplicant` will sometimes not
respond to a BSSID info request that is sent when connecting. The
`wpa_supplicant` is completely fine other than that.

Timing out requests takes some care since the request protocol does not have any
means of associating requests to responses. Based on experiments, it was found
that the `wpa_supplicant` response pretty fast to requests - all observed ones
were in the low milliseconds on a RPi Zero. The timeout is set to 1 second since
that seems safe and it's also less than the default 5 second GenServer request
timeout.

To make this safer, the low level comms to the `wpa_supplicant` now serializes
requests. Serializion was unintentionally done at a higher level so this doesn't
change anything, but its much easier to see now. I also ran an experiment that
exercised multiple outstanding requests without serialization and the dropped
BSSID issue was able to cause responses to be mixed up. I didn't like this at
all since if the upper layers ever were able to schedule multiple requests
simultaneously, the result would almost certainly be hard to debug.

- Serialize wpa_supplicant requests
- Add timer
- Be more explicit when mocking unknown wpa_supplicant responses
