### PR TITLE
Don't request BSS information after association

### DIFF
--- a/lib/vintage_net_wifi/access_point.ex
+++ b/lib/vintage_net_wifi/access_point.ex
@@ -46,7 +46,24 @@ defmodule VintageNetWiFi.AccessPoint do
         }
 
   @doc """
-  Create a new AccessPoint struct
+  Create an AccessPoint when only the BSSID is known
+  """
+  @spec new(any) :: VintageNetWiFi.AccessPoint.t()
+  def new(bssid) do
+    %__MODULE__{
+      bssid: bssid,
+      frequency: 0,
+      band: :unknown,
+      channel: 0,
+      signal_dbm: -99,
+      signal_percent: 0,
+      flags: [],
+      ssid: ""
+    }
+  end
+
+  @doc """
+  Create a new AccessPoint with all of the information
   """
   @spec new(String.t(), String.t(), non_neg_integer(), integer(), [flag()]) ::
           VintageNetWiFi.AccessPoint.t()

--- a/lib/vintage_net_wifi/wpa_supplicant.ex
+++ b/lib/vintage_net_wifi/wpa_supplicant.ex
@@ -264,19 +264,10 @@ defmodule VintageNetWiFi.WPASupplicant do
   defp handle_notification({:event, "CTRL-EVENT-CONNECTED", bssid, "completed", _}, state) do
     Logger.info("Connected to AP: #{bssid}")
 
-    case get_access_point_info(state.ll, bssid) do
-      {:ok, ap} ->
-        new_state = %{state | current_ap: ap}
-        update_current_access_point_property(new_state)
-        new_state
-
-      _error ->
-        Logger.warn("Connected and disconnected to AP before we could get info on it: #{bssid}")
-
-        new_state = %{state | current_ap: nil}
-        update_current_access_point_property(new_state)
-        new_state
-    end
+    ap = state.access_points[bssid] || VintageNetWiFi.AccessPoint.new(bssid)
+    new_state = %{state | current_ap: ap}
+    update_current_access_point_property(new_state)
+    new_state
   end
 
   defp handle_notification({:event, "CTRL-EVENT-CONNECTED", bssid, status, _}, state) do

--- a/test/vintage_net_wifi/wpa_supplicant_test.exs
+++ b/test/vintage_net_wifi/wpa_supplicant_test.exs
@@ -368,6 +368,9 @@ defmodule VintageNetWiFi.WPASupplicantTest do
       ssid: "TestLAN"
     }
 
+    # Make the AP appear
+    MockWPASupplicant.send_message(context.mock, "<2>CTRL-EVENT-BSS-ADDED 0 78:8a:20:87:7a:50")
+
     # Try connecting
     MockWPASupplicant.send_message(
       context.mock,
@@ -399,15 +402,41 @@ defmodule VintageNetWiFi.WPASupplicantTest do
     )
 
     assert_receive {VintageNet, ^current_ap_property, ^ap, nil, _}
+  end
 
-    # Test race condition where AP connects and disconnects before we get around to
-    # asking about it.
+  test "current_ap property is set when unknown", context do
+    MockWPASupplicant.set_responses(context.mock, %{
+      "ATTACH" => "OK\n",
+      "PING" => "PONG\n",
+      "BSS 0" => "",
+      "BSS 78:8a:20:87:7a:50" =>
+        "id=0\nbssid=78:8a:20:87:7a:50\nfreq=2437\nbeacon_int=100\ncapabilities=0x0431\nqual=0\nnoise=-89\nlevel=-71\ntsf=0000333220048880\nage=14\nie=0008426f7062654c414e010882848b968c1298240301062a01003204b048606c0b0504000a00002d1aac011bffffff00000000000000000001000000000000000000003d1606080c000000000000000000000000000000000000007f080000000000000040dd180050f2020101000003a4000027a4000042435e0062322f00dd0900037f01010000ff7fdd1300156d00010100010237e58106788a20867a5030140100000fac040100000fac040100000fac020000\nflags=[WPA2-PSK-CCMP][ESS]\nssid=TestLAN\nsnr=18\nest_throughput=48000\nupdate_idx=1\nbeacon_ie=0008426f7062654c414e010882848b968c1298240301060504010300002a01003204b048606c0b0504000a00002d1aac011bffffff00000000000000000001000000000000000000003d1606080c000000000000000000000000000000000000007f080000000000000040dd180050f2020101000003a4000027a4000042435e0062322f00dd0900037f01010000ff7fdd1300156d00010100010237e58106788a20867a5030140100000fac040100000fac040100000fac020000\n"
+    })
+
+    _supplicant =
+      start_supervised!(
+        {WPASupplicant,
+         wpa_supplicant: "",
+         wpa_supplicant_conf_path: "/dev/null",
+         ifname: "test_wlan0",
+         control_path: context.socket_path}
+      )
+
+    Process.sleep(100)
+
+    current_ap_property = ["interface", "test_wlan0", "wifi", "current_ap"]
+    VintageNet.PropertyTable.clear(VintageNet, current_ap_property)
+    VintageNet.subscribe(current_ap_property)
+
+    ap = VintageNetWiFi.AccessPoint.new("78:8a:20:87:7a:50")
+
+    # Try connecting even though AP hasn't been announced
     MockWPASupplicant.send_message(
       context.mock,
-      "<1>CTRL-EVENT-CONNECTED - Connection to 11:22:33:44:55:66 completed (reauth) [id=0 id_str=]"
+      "<1>CTRL-EVENT-CONNECTED - Connection to 78:8a:20:87:7a:50 completed (reauth) [id=0 id_str=]"
     )
 
-    refute_receive {VintageNet, ^current_ap_property, _, _, _}
+    assert_receive {VintageNet, ^current_ap_property, nil, ^ap, _}
   end
 
   test "get signal info using SIGNAL_POLL", context do


### PR DESCRIPTION
Since this BSS request was often getting dropped by the `wpa_supplicant`
when in high density AP areas, it seems easier to just not send it. It
turns out that the information being request was already known.
