### PR TITLE
Move BSSID requests to a separate process

### DIFF
--- a/lib/vintage_net_wifi/access_point.ex
+++ b/lib/vintage_net_wifi/access_point.ex
@@ -46,7 +46,24 @@ defmodule VintageNetWiFi.AccessPoint do
         }
 
   @doc """
-  Create a new AccessPoint struct
+  Create an AccessPoint when only the BSSID is known
+  """
+  @spec new(any) :: VintageNetWiFi.AccessPoint.t()
+  def new(bssid) do
+    %__MODULE__{
+      bssid: bssid,
+      frequency: 0,
+      band: :unknown,
+      channel: 0,
+      signal_dbm: -99,
+      signal_percent: 0,
+      flags: [],
+      ssid: ""
+    }
+  end
+
+  @doc """
+  Create a new AccessPoint with all of the information
   """
   @spec new(String.t(), String.t(), non_neg_integer(), integer(), [flag()]) ::
           VintageNetWiFi.AccessPoint.t()

--- a/lib/vintage_net_wifi/bssid_requester.ex
+++ b/lib/vintage_net_wifi/bssid_requester.ex
@@ -1,0 +1,149 @@
+defmodule VintageNetWiFi.BSSIDRequester do
+  use GenServer
+
+  alias VintageNetWiFi.{WPASupplicantDecoder, WPASupplicantLL}
+  require Logger
+
+  @moduledoc """
+  Request access point information asynchronously
+
+  Getting access point information is important, but it's easy to fall
+  behind and start blocking more important requests. This GenServer
+  handles this separate from the main WPASupplicant GenServer.
+  """
+
+  @doc """
+  Start a GenServer
+
+  Arguments:
+
+  * `:ll` - the WPASupplicantLL GenServer pid
+  * `:notification_pid` - where to send response messages
+  """
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(init_args) do
+    GenServer.start_link(__MODULE__, init_args)
+  end
+
+  @doc """
+  Get info on all known access points
+
+  This is the get everything all at once call. Everything is sent back.
+  If it's not known, then it's not known.
+  """
+  @spec get_all_access_points(GenServer.server(), any()) :: :ok
+  def get_all_access_points(server, cookie) when not is_nil(server) do
+    GenServer.cast(server, {:get_all_access_points, cookie})
+  end
+
+  @doc """
+  Request information on a BSSID or an access point index
+
+  The response comes back to the process that started this GenServer with the
+  details.
+  """
+  @spec get_access_point_info(GenServer.server(), String.t() | non_neg_integer(), any()) :: :ok
+  def get_access_point_info(server, index_or_bssid, cookie) when not is_nil(server) do
+    GenServer.cast(server, {:get_access_point_info, index_or_bssid, cookie})
+  end
+
+  @doc """
+  Don't bother looking up AP info
+
+  This request doesn't do anything but send back a message to remove an access point.
+  It's needed for flushing out data returned asynchronously from `get_access_point_info/2`
+  calls
+  """
+  @spec forget_access_point_info(GenServer.server(), String.t() | non_neg_integer(), any()) :: :ok
+  def forget_access_point_info(server, index_or_bssid, cookie) when not is_nil(server) do
+    GenServer.cast(server, {:forget_access_point_info, index_or_bssid, cookie})
+  end
+
+  @impl GenServer
+  def init(init_args) do
+    state = %{
+      ll: Keyword.fetch!(init_args, :ll),
+      notification_pid: Keyword.fetch!(init_args, :notification_pid)
+    }
+
+    {:ok, state}
+  end
+
+  @impl GenServer
+  def handle_cast({:get_all_access_points, cookie}, state) do
+    all_bss = get_all_bss(state)
+    send_result(state, all_bss, cookie)
+    {:noreply, state}
+  end
+
+  def handle_cast({:get_access_point_info, index_or_bssid, cookie}, state) do
+    case make_bss_request(state, index_or_bssid) do
+      {:ok, ap_or_peer} ->
+        send_result(state, ap_or_peer, cookie)
+
+      {:error, reason} ->
+        Logger.info(
+          "Ignoring error getting info on BSSID #{inspect(index_or_bssid)}: #{inspect(reason)}"
+        )
+    end
+
+    {:noreply, state}
+  end
+
+  def handle_cast({:forget_access_point_info, index_or_bssid, cookie}, state) do
+    send_result(state, index_or_bssid, cookie)
+    {:noreply, state}
+  end
+
+  defp send_result(state, result, cookie) do
+    send(state.notification_pid, {:bssid_result, result, cookie})
+  end
+
+  defp get_all_bss(state) do
+    get_all_bss(state, 0, %{})
+  end
+
+  defp get_all_bss(state, index, acc) do
+    case make_bss_request(state, index) do
+      {:ok, ap} ->
+        get_all_bss(state, index + 1, Map.put(acc, ap.bssid, ap))
+
+      _error ->
+        acc
+    end
+  end
+
+  defp make_bss_request(state, index_or_bssid) do
+    case WPASupplicantLL.control_request(state.ll, "BSS #{index_or_bssid}") do
+      {:ok, raw_response} ->
+        raw_response
+        |> WPASupplicantDecoder.decode_kv_response()
+        |> decode_bss_response()
+
+      error ->
+        error
+    end
+  end
+
+  defp decode_bss_response(%{"mesh_id" => _} = mesh_response) do
+    {:ok, VintageNetWiFi.MeshPeer.new(mesh_response)}
+  end
+
+  defp decode_bss_response(%{
+         "freq" => frequency_string,
+         "level" => level_string,
+         "flags" => flags_string,
+         "ssid" => ssid,
+         "bssid" => bssid
+       }) do
+    frequency = String.to_integer(frequency_string)
+    flags = WPASupplicantDecoder.parse_flags(flags_string)
+    signal_dbm = String.to_integer(level_string)
+
+    {:ok, VintageNetWiFi.AccessPoint.new(bssid, ssid, frequency, signal_dbm, flags)}
+  end
+
+  defp decode_bss_response(_other) do
+    {:error, :unknown}
+  end
+end

--- a/lib/vintage_net_wifi/wpa_supplicant.ex
+++ b/lib/vintage_net_wifi/wpa_supplicant.ex
@@ -264,19 +264,10 @@ defmodule VintageNetWiFi.WPASupplicant do
   defp handle_notification({:event, "CTRL-EVENT-CONNECTED", bssid, "completed", _}, state) do
     Logger.info("Connected to AP: #{bssid}")
 
-    case get_access_point_info(state.ll, bssid) do
-      {:ok, ap} ->
-        new_state = %{state | current_ap: ap}
-        update_current_access_point_property(new_state)
-        new_state
-
-      _error ->
-        Logger.warn("Connected and disconnected to AP before we could get info on it: #{bssid}")
-
-        new_state = %{state | current_ap: nil}
-        update_current_access_point_property(new_state)
-        new_state
-    end
+    ap = state.access_points[bssid] || VintageNetWiFi.AccessPoint.new(bssid)
+    new_state = %{state | current_ap: ap}
+    update_current_access_point_property(new_state)
+    new_state
   end
 
   defp handle_notification({:event, "CTRL-EVENT-CONNECTED", bssid, status, _}, state) do

--- a/test/vintage_net_wifi/wpa_supplicant_test.exs
+++ b/test/vintage_net_wifi/wpa_supplicant_test.exs
@@ -368,6 +368,9 @@ defmodule VintageNetWiFi.WPASupplicantTest do
       ssid: "TestLAN"
     }
 
+    # Make the AP appear
+    MockWPASupplicant.send_message(context.mock, "<2>CTRL-EVENT-BSS-ADDED 0 78:8a:20:87:7a:50")
+
     # Try connecting
     MockWPASupplicant.send_message(
       context.mock,
@@ -399,15 +402,41 @@ defmodule VintageNetWiFi.WPASupplicantTest do
     )
 
     assert_receive {VintageNet, ^current_ap_property, ^ap, nil, _}
+  end
 
-    # Test race condition where AP connects and disconnects before we get around to
-    # asking about it.
+  test "current_ap property is set when unknown", context do
+    MockWPASupplicant.set_responses(context.mock, %{
+      "ATTACH" => "OK\n",
+      "PING" => "PONG\n",
+      "BSS 0" => "",
+      "BSS 78:8a:20:87:7a:50" =>
+        "id=0\nbssid=78:8a:20:87:7a:50\nfreq=2437\nbeacon_int=100\ncapabilities=0x0431\nqual=0\nnoise=-89\nlevel=-71\ntsf=0000333220048880\nage=14\nie=0008426f7062654c414e010882848b968c1298240301062a01003204b048606c0b0504000a00002d1aac011bffffff00000000000000000001000000000000000000003d1606080c000000000000000000000000000000000000007f080000000000000040dd180050f2020101000003a4000027a4000042435e0062322f00dd0900037f01010000ff7fdd1300156d00010100010237e58106788a20867a5030140100000fac040100000fac040100000fac020000\nflags=[WPA2-PSK-CCMP][ESS]\nssid=TestLAN\nsnr=18\nest_throughput=48000\nupdate_idx=1\nbeacon_ie=0008426f7062654c414e010882848b968c1298240301060504010300002a01003204b048606c0b0504000a00002d1aac011bffffff00000000000000000001000000000000000000003d1606080c000000000000000000000000000000000000007f080000000000000040dd180050f2020101000003a4000027a4000042435e0062322f00dd0900037f01010000ff7fdd1300156d00010100010237e58106788a20867a5030140100000fac040100000fac040100000fac020000\n"
+    })
+
+    _supplicant =
+      start_supervised!(
+        {WPASupplicant,
+         wpa_supplicant: "",
+         wpa_supplicant_conf_path: "/dev/null",
+         ifname: "test_wlan0",
+         control_path: context.socket_path}
+      )
+
+    Process.sleep(100)
+
+    current_ap_property = ["interface", "test_wlan0", "wifi", "current_ap"]
+    VintageNet.PropertyTable.clear(VintageNet, current_ap_property)
+    VintageNet.subscribe(current_ap_property)
+
+    ap = VintageNetWiFi.AccessPoint.new("78:8a:20:87:7a:50")
+
+    # Try connecting even though AP hasn't been announced
     MockWPASupplicant.send_message(
       context.mock,
-      "<1>CTRL-EVENT-CONNECTED - Connection to 11:22:33:44:55:66 completed (reauth) [id=0 id_str=]"
+      "<1>CTRL-EVENT-CONNECTED - Connection to 78:8a:20:87:7a:50 completed (reauth) [id=0 id_str=]"
     )
 
-    refute_receive {VintageNet, ^current_ap_property, _, _, _}
+    assert_receive {VintageNet, ^current_ap_property, nil, ^ap, _}
   end
 
   test "get signal info using SIGNAL_POLL", context do


### PR DESCRIPTION
Move BSSID requests to a separate process

This separates the BSSID informational requests from the main path so that can
be done asynchronous and interleaved with more important requests. This way, if
there is a massive flurry of BSSID notifications, processing those notifications
(even though it's usually quick) will not delay handing of notifications.

This refactoring was originally done since it was hypothesized that
notifications would queue up and eventually get dropped at the Unix domain
socket level. This wasn't happening. However, since BSSID info requests have
been dropped by the `wpa_supplicant`, this separation feels "good" since it
opens up oportunities to reduce redundant requests and possibly to batch updates
together to minimize the overhead of dealing with tons of incremental AP
notifications.
