### PR TITLE
Fix warnings found by Elixir 1.12

### DIFF
--- a/lib/vintage_net/technology/wifi.ex
+++ b/lib/vintage_net/technology/wifi.ex
@@ -32,7 +32,9 @@ defmodule VintageNet.Technology.WiFi do
     |> Map.put(:type, VintageNetWiFi)
   end
 
+  @impl VintageNet.Technology
   defdelegate ioctl(ifname, command, args), to: VintageNetWiFi
 
+  @impl VintageNet.Technology
   defdelegate check_system(opts), to: VintageNetWiFi
 end


### PR DESCRIPTION
Fixes:

```
warning: module attribute @impl was not set for function ioctl/3 callback (specified in VintageNet.Technology). This either means you forgot to add the "@impl true" annotation before the definition or that you are accidentally overriding this callback
  lib/vintage_net/technology/wifi.ex:35: VintageNet.Technology.WiFi (module)

warning: module attribute @impl was not set for function check_system/1 callback (specified in VintageNet.Technology). This either means you forgot to add the "@impl true" annotation before the definition or that you are accidentally overriding this callback
  lib/vintage_net/technology/wifi.ex:37: VintageNet.Technology.WiFi (module)
```
