### PR TITLE
Support WPA3 and transitional WPA2/WPA3 networks

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,9 +92,13 @@ The `:vintage_net_wifi` key has the following common fields:
     * `:mesh` - mesh mode
   * `:ssid` - The SSID for the network
   * `:key_mgmt` - WiFi security mode (`:wpa_psk` for WPA2, `:none` for no
-    password or WEP)
+    password or WEP, `:sae` for pure WPA3, or `:wpa_psk_sha256` for transitional
+    WPA2/WPA3)
   * `:psk` - A WPA2 passphrase or the raw PSK. If a passphrase is passed in, it
     will be converted to a PSK and discarded.
+  * `:sae_password` - A password for use with SAE authentication. This is
+    similar to a passphrase that you could supply to `:psk`, but it has less
+    length restrictions.
   * `:priority` - The priority to set for a network if you are using multiple
     network configurations
   * `:scan_ssid` - Scan with SSID-specific Probe Request frames (this can be
@@ -102,13 +106,18 @@ The `:vintage_net_wifi` key has the following common fields:
     this will add latency to scanning, so enable this only when needed)
   * `:frequency` - When in `:ibss` mode, use this channel frequency (in MHz).
     For example, specify 2412 for channel 1.
+  * `:ieee80211w` - Whether management frame protection is enabled. Set to `0`,
+    `1`, `2` or `:disabled`, `:optional`, `:required`.
 
-See the [official
-docs](https://w1.fi/cgit/hostap/plain/wpa_supplicant/wpa_supplicant.conf) for
-the complete list of options.
-If there is a config from `wpa_supplicant.conf` missing from VintageNet, one may
-supply a `wpa_supplicant_conf` key that will override all other configuration for `vintage_net_wifi`.
-Example:
+These keys fairly directly map to the keys in the [official
+docs](https://w1.fi/cgit/hostap/plain/wpa_supplicant/wpa_supplicant.conf).
+`VintageNetWiFi` performs some checks on the keys to avoid typos and other easy
+mistakes from breaking the `wpa_supplicant.conf` file. To inspect the generated
+configuration, run `File.read("/tmp/vintage_net/wpa_supplicant.conf.wlan0")`.
+
+If you do not want VintageNetWiFi to generate a `wpa_supplicant.conf` file for you, you
+can specify the contents for yourself by using the `:wpa_supplicant_conf` key.
+For example,
 
 ```elixir
 iex> VintageNet.configure("wlan0", %{
@@ -126,7 +135,9 @@ iex> VintageNet.configure("wlan0", %{
     })
 ```
 
-Please note that the syntax of the `wpa_supplicant_conf` key is **NOT** validated by VintageNet.
+Please note that the syntax of the `:wpa_supplicant_conf` key is **NOT**
+validated by VintageNet and we do not recommend them method unless you are
+troubleshooting the `wpa_supplicant` or are working on a new feature.
 
 Example of WPA PSK
 
@@ -162,6 +173,46 @@ iex> VintageNet.configure("wlan0", %{
         ]
       },
       ipv4: %{method: :dhcp}
+    })
+```
+
+WPA3 support is possible, but you'll find it's limited by commonly used WiFi
+modules and device drivers. If you would like to try, here's a configuration to
+attach to a pure WPA3 network.
+
+```elixir
+iex> VintageNet.configure("wlan0", %{
+      type: VintageNetWiFi,
+      ipv4: %{method: :dhcp},
+      vintage_net_wifi: %{
+        networks: [
+          %{
+            key_mgmt: :sae,
+            ssid: "my_network_ssid",
+            sae_password: "a_password",
+            ieee80211w: 2
+          }
+        ]
+      }
+    })
+```
+
+A transitional WPA2/WPA3 configuration looks like:
+
+```elixir
+iex> VintageNet.configure("wlan0", %{
+      type: VintageNetWiFi,
+      ipv4: %{method: :dhcp},
+      vintage_net_wifi: %{
+        networks: [
+          %{
+            key_mgmt: :wpa_psk_sha256,
+            ssid: "my_network_ssid",
+            psk: "a_password",
+            ieee80211w: 2
+          }
+        ]
+      }
     })
 ```
 

--- a/test/vintage_net_wifi_test.exs
+++ b/test/vintage_net_wifi_test.exs
@@ -411,6 +411,128 @@ defmodule VintageNetWiFiTest do
     assert output == VintageNetWiFi.to_raw_config("wlan0", input, default_opts())
   end
 
+  test "create a pure WPA3 WiFi configuration" do
+    input = %{
+      type: VintageNetWiFi,
+      vintage_net_wifi: %{
+        networks: [
+          %{
+            ssid: "testing",
+            sae_password: "hunter2",
+            key_mgmt: :sae,
+            ieee80211w: 2
+          }
+        ]
+      },
+      ipv4: %{method: :dhcp},
+      hostname: "unit_test"
+    }
+
+    output = %RawConfig{
+      ifname: "wlan0",
+      type: VintageNetWiFi,
+      source_config: VintageNetWiFi.normalize(input),
+      required_ifnames: ["wlan0"],
+      child_specs: [
+        {VintageNetWiFi.WPASupplicant,
+         [
+           wpa_supplicant: "wpa_supplicant",
+           ifname: "wlan0",
+           wpa_supplicant_conf_path: "/tmp/vintage_net/wpa_supplicant.conf.wlan0",
+           control_path: "/tmp/vintage_net/wpa_supplicant",
+           ap_mode: false,
+           verbose: false
+         ]},
+        udhcpc_child_spec("wlan0", "unit_test"),
+        {VintageNet.Interface.InternetConnectivityChecker, "wlan0"}
+      ],
+      restart_strategy: :rest_for_one,
+      files: [
+        {"/tmp/vintage_net/wpa_supplicant.conf.wlan0",
+         """
+         ctrl_interface=/tmp/vintage_net/wpa_supplicant
+         country=00
+         network={
+         ssid="testing"
+         key_mgmt=SAE
+         mode=0
+         ieee80211w=2
+         sae_password="hunter2"
+         }
+         """}
+      ],
+      up_cmds: [{:run, "ip", ["link", "set", "wlan0", "up"]}],
+      down_cmds: [
+        {:run_ignore_errors, "ip", ["addr", "flush", "dev", "wlan0", "label", "wlan0"]},
+        {:run, "ip", ["link", "set", "wlan0", "down"]}
+      ],
+      cleanup_files: ["/tmp/vintage_net/wpa_supplicant/wlan0"]
+    }
+
+    assert output == VintageNetWiFi.to_raw_config("wlan0", input, default_opts())
+  end
+
+  test "create a mixed WPA2-PSK/WPA3-SAE WiFi configuration" do
+    input = %{
+      type: VintageNetWiFi,
+      vintage_net_wifi: %{
+        networks: [
+          %{
+            ssid: "testing",
+            psk: "password",
+            key_mgmt: :wpa_psk_sha256,
+            ieee80211w: 2
+          }
+        ]
+      },
+      ipv4: %{method: :dhcp},
+      hostname: "unit_test"
+    }
+
+    output = %RawConfig{
+      ifname: "wlan0",
+      type: VintageNetWiFi,
+      source_config: VintageNetWiFi.normalize(input),
+      required_ifnames: ["wlan0"],
+      child_specs: [
+        {VintageNetWiFi.WPASupplicant,
+         [
+           wpa_supplicant: "wpa_supplicant",
+           ifname: "wlan0",
+           wpa_supplicant_conf_path: "/tmp/vintage_net/wpa_supplicant.conf.wlan0",
+           control_path: "/tmp/vintage_net/wpa_supplicant",
+           ap_mode: false,
+           verbose: false
+         ]},
+        udhcpc_child_spec("wlan0", "unit_test"),
+        {VintageNet.Interface.InternetConnectivityChecker, "wlan0"}
+      ],
+      restart_strategy: :rest_for_one,
+      files: [
+        {"/tmp/vintage_net/wpa_supplicant.conf.wlan0",
+         """
+         ctrl_interface=/tmp/vintage_net/wpa_supplicant
+         country=00
+         network={
+         ssid="testing"
+         key_mgmt=WPA2-PSK-SHA256
+         mode=0
+         ieee80211w=2
+         psk=5747B578C5FAF01543C4CEC284A772E1037C7C84C03C9A2404DAB5CBF9C74394
+         }
+         """}
+      ],
+      up_cmds: [{:run, "ip", ["link", "set", "wlan0", "up"]}],
+      down_cmds: [
+        {:run_ignore_errors, "ip", ["addr", "flush", "dev", "wlan0", "label", "wlan0"]},
+        {:run, "ip", ["link", "set", "wlan0", "down"]}
+      ],
+      cleanup_files: ["/tmp/vintage_net/wpa_supplicant/wlan0"]
+    }
+
+    assert output == VintageNetWiFi.to_raw_config("wlan0", input, default_opts())
+  end
+
   test "create an open WiFi configuration" do
     input = %{
       type: VintageNetWiFi,


### PR DESCRIPTION
This is currently draft since I'm currently getting errors with the WiFi adapters I'm using. It could be the case that either they or their device drivers have WPA3 settings disabled.

I'm also interested in updating the cookbook and `quick_configure` functions to make it easier to connect to WPA3 networks since the `wpa_supplicant` config is fairly technical on options.