### PR TITLE
Use buildroot host pkg-config instead of system pkg-config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ else
     else
 
         # Use pkg-config to find libnl
-        PKG_CONFIG = $(shell which pkg-config)
+        PKG_CONFIG = $(PKG_CONFIG_SYSROOT_DIR)/../../bin/pkg-config
         ifeq ($(PKG_CONFIG),)
             $(error pkg-config required to build. Install by running "brew install pkg-config")
         endif


### PR DESCRIPTION
This is related to issue #66.  I explained my findings in the discussion there.