### PR TITLE
Reduce some log noise

### DIFF
--- a/lib/vintage_net_wifi/bssid_requester.ex
+++ b/lib/vintage_net_wifi/bssid_requester.ex
@@ -82,7 +82,7 @@ defmodule VintageNetWiFi.BSSIDRequester do
         send_result(state, ap_or_peer, cookie)
 
       {:error, reason} ->
-        Logger.info(
+        Logger.warn(
           "Ignoring error getting info on BSSID #{inspect(index_or_bssid)}: #{inspect(reason)}"
         )
     end

--- a/lib/vintage_net_wifi/wpa_supplicant.ex
+++ b/lib/vintage_net_wifi/wpa_supplicant.ex
@@ -259,7 +259,7 @@ defmodule VintageNetWiFi.WPASupplicant do
   end
 
   defp handle_notification({:event, "CTRL-EVENT-CONNECTED", bssid, "completed", _}, state) do
-    Logger.info("Connected to AP: #{bssid}")
+    Logger.debug("Connected to AP: #{bssid}")
 
     case state.access_points[bssid] do
       nil ->
@@ -422,12 +422,12 @@ defmodule VintageNetWiFi.WPASupplicant do
   end
 
   defp handle_notification({:info, message}, state) do
-    Logger.info("wpa_supplicant(#{state.ifname}): #{message}")
+    Logger.debug("wpa_supplicant(#{state.ifname}): #{message}")
     state
   end
 
   defp handle_notification(unhandled, state) do
-    Logger.info("WPASupplicant ignoring #{inspect(unhandled)}")
+    Logger.warn("WPASupplicant ignoring #{inspect(unhandled)}")
     state
   end
 


### PR DESCRIPTION
* Info messages from `WPASupplicant` don't need to be level info.
  Opted to leave at `debug` in case someone reaallly wants to see them
* Changed unhandled WPASupplicant message to a warn
* Changed AP connection log to a debug