### PR TITLE
wpa_supplicant: fall back to wext

### DIFF
--- a/lib/vintage_net_wifi/wpa_supplicant.ex
+++ b/lib/vintage_net_wifi/wpa_supplicant.ex
@@ -109,9 +109,21 @@ defmodule VintageNetWiFi.WPASupplicant do
 
         verbose_flag = if state.verbose, do: ["-dd"], else: []
 
+        # -i ifname      // which interface
+        # -Dnl80211,wext // try the nl80211 driver first, then wext
+        # -c config_file // use our config file
+        # -dd            // verbose
+        args = [
+          "-i",
+          state.ifname,
+          "-Dnl80211,wext",
+          "-c",
+          state.wpa_supplicant_conf_path | verbose_flag
+        ]
+
         MuonTrap.Daemon.start_link(
           state.wpa_supplicant,
-          ["-i", state.ifname, "-c", state.wpa_supplicant_conf_path | verbose_flag],
+          args,
           VintageNet.Command.add_muon_options(stderr_to_stdout: true, log_output: :debug)
         )
       else


### PR DESCRIPTION
If a driver somehow only supports wext, automatically try it if it's
available. This is required for the RTL8818EU driver on the GRiSP2.
