### PR TITLE
Raise command timeout to wpa_supplicant

### DIFF
--- a/lib/vintage_net_wifi/wpa_supplicant_ll.ex
+++ b/lib/vintage_net_wifi/wpa_supplicant_ll.ex
@@ -150,7 +150,7 @@ defmodule VintageNetWiFi.WPASupplicantLL do
   defp do_send_request(state, {message, from} = request) do
     case :gen_udp.send(state.socket, {:local, state.control_file}, 0, message) do
       :ok ->
-        {:ok, timer} = :timer.send_after(1000, :request_timeout)
+        {:ok, timer} = :timer.send_after(4000, :request_timeout)
         %{state | outstanding: request, request_timer: timer}
 
       error ->


### PR DESCRIPTION
This raises the timeout from 1 second to 4 seconds. The GenServer
timeout is still 5 seconds, so there's still some headroom before timing
out with an exception.

The reason for this change is 1 second is too short for the initial
connection to the `wpa_supplicant` on a GRiSP 2. While the short timeout
still works, it causes the `wpa_supplicant` to be restarted when it
would have been faster to just wait for the slightly late response.
