### PR TITLE
Work around wpa_supplicant SSID parser

### DIFF
--- a/test/vintage_net_wifi_test.exs
+++ b/test/vintage_net_wifi_test.exs
@@ -2324,4 +2324,130 @@ defmodule VintageNetWiFiTest do
 
     assert output == VintageNetWiFi.to_raw_config("wlan0", input, default_opts())
   end
+
+  test "create a WiFi configuration with SSID that exceeds max length with backslashes" do
+    # This test works around an issue where backslashes count in the SSID length
+    # calculation in wpa_supplicant. The workaround is to trim the SSID for now, since the
+    # alternative is wpa_supplicant continuously restarting.
+
+    # In this test, the SSID will be trimmed from 60 characters to 32 characters.
+    input = %{
+      type: VintageNetWiFi,
+      vintage_net_wifi: %{
+        networks: [
+          %{
+            ssid: :binary.copy(<<0>>, 30),
+            psk: "0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF",
+            key_mgmt: :wpa_psk
+          }
+        ]
+      },
+      ipv4: %{method: :dhcp},
+      hostname: "unit_test"
+    }
+
+    output = %RawConfig{
+      ifname: "wlan0",
+      type: VintageNetWiFi,
+      source_config: VintageNetWiFi.normalize(input),
+      required_ifnames: ["wlan0"],
+      child_specs: [
+        {VintageNetWiFi.WPASupplicant,
+         [
+           wpa_supplicant: "wpa_supplicant",
+           ifname: "wlan0",
+           wpa_supplicant_conf_path: "/tmp/vintage_net/wpa_supplicant.conf.wlan0",
+           control_path: "/tmp/vintage_net/wpa_supplicant",
+           ap_mode: false,
+           verbose: false
+         ]},
+        udhcpc_child_spec("wlan0", "unit_test"),
+        {VintageNet.Connectivity.InternetChecker, "wlan0"}
+      ],
+      restart_strategy: :rest_for_one,
+      files: [
+        {"/tmp/vintage_net/wpa_supplicant.conf.wlan0",
+         """
+         ctrl_interface=/tmp/vintage_net/wpa_supplicant
+         country=00
+         wps_cred_processing=1
+         network={
+         ssid="\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0"
+         key_mgmt=WPA-PSK
+         mode=0
+         psk=0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF
+         }
+         """}
+      ],
+      down_cmds: [
+        {:run_ignore_errors, "ip", ["addr", "flush", "dev", "wlan0", "label", "wlan0"]},
+        {:run, "ip", ["link", "set", "wlan0", "down"]}
+      ],
+      up_cmds: [{:run, "ip", ["link", "set", "wlan0", "up"]}],
+      cleanup_files: ["/tmp/vintage_net/wpa_supplicant/wlan0"]
+    }
+
+    assert output == VintageNetWiFi.to_raw_config("wlan0", input, default_opts())
+  end
+
+  test "create a WiFi configuration with SSID that exceeds max length with orphan backslash" do
+    # This is a special case of the above test
+    input = %{
+      type: VintageNetWiFi,
+      vintage_net_wifi: %{
+        networks: [
+          %{
+            ssid: "a" <> :binary.copy(<<0>>, 30),
+            psk: "0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF",
+            key_mgmt: :wpa_psk
+          }
+        ]
+      },
+      ipv4: %{method: :dhcp},
+      hostname: "unit_test"
+    }
+
+    output = %RawConfig{
+      ifname: "wlan0",
+      type: VintageNetWiFi,
+      source_config: VintageNetWiFi.normalize(input),
+      required_ifnames: ["wlan0"],
+      child_specs: [
+        {VintageNetWiFi.WPASupplicant,
+         [
+           wpa_supplicant: "wpa_supplicant",
+           ifname: "wlan0",
+           wpa_supplicant_conf_path: "/tmp/vintage_net/wpa_supplicant.conf.wlan0",
+           control_path: "/tmp/vintage_net/wpa_supplicant",
+           ap_mode: false,
+           verbose: false
+         ]},
+        udhcpc_child_spec("wlan0", "unit_test"),
+        {VintageNet.Connectivity.InternetChecker, "wlan0"}
+      ],
+      restart_strategy: :rest_for_one,
+      files: [
+        {"/tmp/vintage_net/wpa_supplicant.conf.wlan0",
+         """
+         ctrl_interface=/tmp/vintage_net/wpa_supplicant
+         country=00
+         wps_cred_processing=1
+         network={
+         ssid="a\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0"
+         key_mgmt=WPA-PSK
+         mode=0
+         psk=0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF
+         }
+         """}
+      ],
+      down_cmds: [
+        {:run_ignore_errors, "ip", ["addr", "flush", "dev", "wlan0", "label", "wlan0"]},
+        {:run, "ip", ["link", "set", "wlan0", "down"]}
+      ],
+      up_cmds: [{:run, "ip", ["link", "set", "wlan0", "up"]}],
+      cleanup_files: ["/tmp/vintage_net/wpa_supplicant/wlan0"]
+    }
+
+    assert output == VintageNetWiFi.to_raw_config("wlan0", input, default_opts())
+  end
 end


### PR DESCRIPTION
In the unusual case where there are a lot of characters being escaped,
the wpa_supplicant SSID parser will reject the ssid. It's not clear that
these are even valid SSIDs or just someone messing around. Trimming them
will make wpa_supplicant pass its checks even though it almost certainly
won't connect. This seems better than the current behavior of restarting
wpa_supplicant when it exits.
