### PR TITLE
WPA2 SHA256 updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,8 +92,8 @@ The `:vintage_net_wifi` key has the following common fields:
     * `:mesh` - mesh mode
   * `:ssid` - The SSID for the network
   * `:key_mgmt` - WiFi security mode (`:wpa_psk` for WPA2, `:none` for no
-    password or WEP, `:sae` for pure WPA3, or `:wpa_psk_sha256` for transitional
-    WPA2/WPA3)
+    password or WEP, `:sae` for pure WPA3, or `:wpa_psk_sha256` for WPA2 with
+    SHA256)
   * `:psk` - A WPA2 passphrase or the raw PSK. If a passphrase is passed in, it
     will be converted to a PSK and discarded.
   * `:sae_password` - A password for use with SAE authentication. This is
@@ -197,7 +197,7 @@ iex> VintageNet.configure("wlan0", %{
     })
 ```
 
-A transitional WPA2/WPA3 configuration looks like:
+WPA2 w/ SHA256 configuration looks like:
 
 ```elixir
 iex> VintageNet.configure("wlan0", %{

--- a/lib/vintage_net_wifi.ex
+++ b/lib/vintage_net_wifi.ex
@@ -419,7 +419,7 @@ defmodule VintageNetWiFi do
 
   defp key_mgmt_to_string(:none), do: "NONE"
   defp key_mgmt_to_string(:wpa_psk), do: "WPA-PSK"
-  defp key_mgmt_to_string(:wpa_psk_sha256), do: "WPA2-PSK-SHA256"
+  defp key_mgmt_to_string(:wpa_psk_sha256), do: "WPA-PSK-SHA256"
   defp key_mgmt_to_string(:wpa_eap), do: "WPA-EAP"
   defp key_mgmt_to_string(:IEEE8021X), do: "IEEE8021X"
   defp key_mgmt_to_string(:sae), do: "SAE"

--- a/test/vintage_net_wifi_test.exs
+++ b/test/vintage_net_wifi_test.exs
@@ -511,7 +511,7 @@ defmodule VintageNetWiFiTest do
          wps_cred_processing=1
          network={
          ssid="testing"
-         key_mgmt=WPA2-PSK-SHA256
+         key_mgmt=WPA-PSK-SHA256
          mode=0
          ieee80211w=2
          psk=5747B578C5FAF01543C4CEC284A772E1037C7C84C03C9A2404DAB5CBF9C74394


### PR DESCRIPTION
I still don't have equipment to test to my knowledge, but there were a couple
misunderstandings and wpa_supplicant complained.

- Fix WPA-PSK-SHA256 spelling to fix wpa_supplicant error
- Remove incorrect references to WPA2 transitional
