### PR TITLE
Support creating WPA2/WPA3 configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,11 @@ The `:vintage_net_wifi` key has the following common fields:
   * `:ssid` - The SSID for the network
   * `:key_mgmt` - WiFi security mode (`:wpa_psk` for WPA2, `:none` for no
     password or WEP, `:sae` for pure WPA3, or `:wpa_psk_sha256` for WPA2 with
-    SHA256)
+    SHA256). Not used if `:allowed_key_mgmt` is set.
+  * `:allowed_key_mgmt` - A list of allowed WiFi security modes. See `:key_mgmt`
+    for options. Supported in v0.12.1+. VintageNetWiFi's configuration
+    normalizer automatically sets `:key_mgmt` to the first option in the list
+    for backwards compatibility with v0.12.0 and earlier.
   * `:psk` - A WPA2 passphrase or the raw PSK. If a passphrase is passed in, it
     will be converted to a PSK and discarded.
   * `:sae_password` - A password for use with SAE authentication. This is

--- a/lib/vintage_net_wifi.ex
+++ b/lib/vintage_net_wifi.ex
@@ -787,7 +787,7 @@ defmodule VintageNetWiFi do
   @doc """
   Configure WiFi using the most common settings
 
-  If your network requires a password (WPA PSK networks):
+  If your network requires a password (WPA2 PSK and WPA3 SAE networks):
 
   ```
   iex> VintageNetWiFi.quick_configure("ssid", "password")
@@ -824,7 +824,7 @@ defmodule VintageNetWiFi do
   end
 
   def quick_configure(ssid, passphrase) do
-    with {:ok, config} <- Cookbook.wpa_psk(ssid, passphrase) do
+    with {:ok, config} <- Cookbook.generic(ssid, passphrase) do
       VintageNet.configure("wlan0", config)
     end
   end

--- a/lib/vintage_net_wifi/cookbook.ex
+++ b/lib/vintage_net_wifi/cookbook.ex
@@ -33,7 +33,7 @@ defmodule VintageNetWiFi.Cookbook do
                ssid: ssid,
                psk: passphrase,
                sae_password: passphrase,
-               key_mgmt: [:sae, :wpa_psk_sha256, :wpa_psk],
+               key_mgmt: [:wpa_psk, :wpa_psk_sha256, :sae],
                ieee80211w: 2
              }
            ]

--- a/lib/vintage_net_wifi/cookbook.ex
+++ b/lib/vintage_net_wifi/cookbook.ex
@@ -9,6 +9,41 @@ defmodule VintageNetWiFi.Cookbook do
   alias VintageNetWiFi.WPA2
 
   @doc """
+  Return a generic configuration for connecting to preshared-key networks
+
+  The returned configuration should be able to connect to an access point
+  configured to use WPA3-only, WPA2/3 transitional or WPA2. The WiFi module
+  must also support WPA3 for this to work.
+
+  Pass an SSID and passphrase. If the SSID and passphrase are ok, you'll get an
+  `:ok` tuple with the configuration. If there's a problem, you'll get an error
+  tuple with a reason.
+  """
+  @spec generic(String.t(), String.t()) ::
+          {:ok, map()} | {:error, WPA2.invalid_ssid_error() | WPA2.invalid_passphrase_error()}
+  def generic(ssid, passphrase) when is_binary(ssid) and is_binary(passphrase) do
+    with :ok <- WPA2.validate_ssid(ssid),
+         :ok <- WPA2.validate_passphrase(passphrase) do
+      {:ok,
+       %{
+         type: VintageNetWiFi,
+         vintage_net_wifi: %{
+           networks: [
+             %{
+               ssid: ssid,
+               psk: passphrase,
+               sae_password: passphrase,
+               key_mgmt: [:sae, :wpa_psk_sha256, :wpa_psk],
+               ieee80211w: 2
+             }
+           ]
+         },
+         ipv4: %{method: :dhcp}
+       }}
+    end
+  end
+
+  @doc """
   Return a configuration for connecting to open WiFi network
 
   Pass an SSID and passphrase. If the SSID and passphrase are ok, you'll get an

--- a/test/vintage_net_wifi/cookbook_test.exs
+++ b/test/vintage_net_wifi/cookbook_test.exs
@@ -3,6 +3,25 @@ defmodule VintageNetWiFi.CookbookTest do
 
   alias VintageNetWiFi.Cookbook
 
+  test "generic/2" do
+    assert {:ok,
+            %{
+              type: VintageNetWiFi,
+              ipv4: %{method: :dhcp},
+              vintage_net_wifi: %{
+                networks: [
+                  %{
+                    key_mgmt: [:sae, :wpa_psk_sha256, :wpa_psk],
+                    psk: "my_passphrase",
+                    ssid: "my_ssid",
+                    ieee80211w: 2,
+                    sae_password: "my_passphrase"
+                  }
+                ]
+              }
+            }} == Cookbook.generic("my_ssid", "my_passphrase")
+  end
+
   test "open_wifi/2" do
     assert {:ok,
             %{

--- a/test/vintage_net_wifi/cookbook_test.exs
+++ b/test/vintage_net_wifi/cookbook_test.exs
@@ -11,7 +11,7 @@ defmodule VintageNetWiFi.CookbookTest do
               vintage_net_wifi: %{
                 networks: [
                   %{
-                    key_mgmt: [:sae, :wpa_psk_sha256, :wpa_psk],
+                    key_mgmt: [:wpa_psk, :wpa_psk_sha256, :sae],
                     psk: "my_passphrase",
                     ssid: "my_ssid",
                     ieee80211w: 2,

--- a/test/vintage_net_wifi_test.exs
+++ b/test/vintage_net_wifi_test.exs
@@ -529,6 +529,43 @@ defmodule VintageNetWiFiTest do
     assert output == VintageNetWiFi.to_raw_config("wlan0", input, default_opts())
   end
 
+  test "normalize creates backwards compatible key_mgmt" do
+    input = %{
+      type: VintageNetWiFi,
+      vintage_net_wifi: %{
+        networks: [
+          %{
+            ssid: "testing",
+            psk: "password",
+            sae_password: "password",
+            key_mgmt: [:wpa_psk, :wpa_psk_sha256, :sae],
+            ieee80211w: 2
+          }
+        ]
+      }
+    }
+
+    normalized_input = %{
+      type: VintageNetWiFi,
+      ipv4: %{method: :dhcp},
+      vintage_net_wifi: %{
+        networks: [
+          %{
+            ssid: "testing",
+            psk: "5747B578C5FAF01543C4CEC284A772E1037C7C84C03C9A2404DAB5CBF9C74394",
+            sae_password: "password",
+            ieee80211w: 2,
+            allowed_key_mgmt: [:wpa_psk, :wpa_psk_sha256, :sae],
+            key_mgmt: :wpa_psk,
+            mode: :infrastructure
+          }
+        ]
+      }
+    }
+
+    assert normalized_input == VintageNetWiFi.normalize(input)
+  end
+
   test "create a WPA2, WPA2 SHA256, WPA3 WiFi configuration" do
     input = %{
       type: VintageNetWiFi,
@@ -538,7 +575,7 @@ defmodule VintageNetWiFiTest do
             ssid: "testing",
             psk: "password",
             sae_password: "password",
-            key_mgmt: [:sae, :wpa_psk_sha256, :wpa_psk],
+            key_mgmt: [:wpa_psk, :wpa_psk_sha256, :sae],
             ieee80211w: 2
           }
         ]
@@ -574,7 +611,7 @@ defmodule VintageNetWiFiTest do
          wps_cred_processing=1
          network={
          ssid="testing"
-         key_mgmt=SAE WPA-PSK-SHA256 WPA-PSK
+         key_mgmt=WPA-PSK WPA-PSK-SHA256 SAE
          mode=0
          ieee80211w=2
          psk=5747B578C5FAF01543C4CEC284A772E1037C7C84C03C9A2404DAB5CBF9C74394


### PR DESCRIPTION
This adds support for passing a list of allowed WiFi encryption
protocols. This lets you make a configuration that will work whether the
AP is using WPA2 or WPA3.

Here's an example that specifies both WPA2 and WPA3 options and supports
WPA2-SHA256 too:

```
%{
  type: VintageNetWiFi,
  vintage_net_wifi: %{
    networks: [
      %{
        ssid: "testing",
        psk: "password",
        sae_password: "password",
        key_mgmt: [:sae, :wpa_psk_sha256, :wpa_psk],
        ieee80211w: 2
      }
    ]
  },
  ipv4: %{method: :dhcp}
}
```

To test, you can either specify the above configuration to `VintageNet.configure` or use `VintageNetWiFi.quick_configure/2` which has been update to support both WPA3 and WPA2.