### PR TITLE
Make management frame protection optional in generic config

### DIFF
--- a/lib/vintage_net_wifi/cookbook.ex
+++ b/lib/vintage_net_wifi/cookbook.ex
@@ -34,7 +34,7 @@ defmodule VintageNetWiFi.Cookbook do
                psk: passphrase,
                sae_password: passphrase,
                key_mgmt: [:wpa_psk, :wpa_psk_sha256, :sae],
-               ieee80211w: 2
+               ieee80211w: 1
              }
            ]
          },

--- a/test/vintage_net_wifi/cookbook_test.exs
+++ b/test/vintage_net_wifi/cookbook_test.exs
@@ -14,7 +14,7 @@ defmodule VintageNetWiFi.CookbookTest do
                     key_mgmt: [:wpa_psk, :wpa_psk_sha256, :sae],
                     psk: "my_passphrase",
                     ssid: "my_ssid",
-                    ieee80211w: 2,
+                    ieee80211w: 1,
                     sae_password: "my_passphrase"
                   }
                 ]

--- a/test/vintage_net_wifi_test.exs
+++ b/test/vintage_net_wifi_test.exs
@@ -576,7 +576,7 @@ defmodule VintageNetWiFiTest do
             psk: "password",
             sae_password: "password",
             key_mgmt: [:wpa_psk, :wpa_psk_sha256, :sae],
-            ieee80211w: 2
+            ieee80211w: 1
           }
         ]
       },
@@ -613,7 +613,7 @@ defmodule VintageNetWiFiTest do
          ssid="testing"
          key_mgmt=WPA-PSK WPA-PSK-SHA256 SAE
          mode=0
-         ieee80211w=2
+         ieee80211w=1
          psk=5747B578C5FAF01543C4CEC284A772E1037C7C84C03C9A2404DAB5CBF9C74394
          sae_password="password"
          }


### PR DESCRIPTION
The generic configuration was requiring frame protection (ieee80211w=2)
since WPA3 requires it. A lot of WPA2 networks support it so this worked
for those as well. The Samsung S23 does not support it in hotspot mode,
though, iee80211w has to be set to optional (1) to support it.

This has also been tested with various WPA2 WiFi networks that supported
frame protection and a WPA3 SAE network.
