### PR TITLE
Add configured?/1

### DIFF
--- a/lib/vintage_net_wifi.ex
+++ b/lib/vintage_net_wifi.ex
@@ -995,4 +995,17 @@ defmodule VintageNetWiFi do
   end
 
   defp trim_orphan_backslash(s), do: s
+
+  @doc """
+  Check if a wlan network interface is configured.
+  """
+  @spec configured?(map | binary) :: boolean
+  def configured?(wlan_ifname) when is_binary(wlan_ifname) do
+    wlan_ifname |> VintageNet.get_configuration() |> configured?()
+  end
+
+  def configured?(wlan_config) when wlan_config == %{type: VintageNetWiFi}, do: false
+  def configured?(%{vintage_net_wifi: %{networks: []}}), do: false
+  def configured?(%{vintage_net_wifi: %{networks: [_ | _]}}), do: true
+  def configured?(_), do: false
 end

--- a/test/vintage_net_wifi_test.exs
+++ b/test/vintage_net_wifi_test.exs
@@ -2661,4 +2661,36 @@ defmodule VintageNetWiFiTest do
 
     assert expected_output == VintageNetWiFi.summarize_access_points(input)
   end
+
+  test "Check if wlan is already configured" do
+    configured = %{
+      type: VintageNetWiFi,
+      ipv4: %{method: :dhcp},
+      vintage_net_wifi: %{
+        networks: [
+          %{
+            key_mgmt: :wpa_psk,
+            ssid: "IEEE",
+            psk: "F42C6FC52DF0EBEF9EBB4B90B38A5F902E83FE1B135A70E23AED762E9710A12E",
+            mode: :infrastructure
+          }
+        ]
+      }
+    }
+
+    empty1 = %{
+      type: VintageNetWiFi
+    }
+
+    empty2 = %{
+      type: VintageNetWiFi,
+      vintage_net_wifi: %{networks: []},
+      ipv4: %{method: :disabled}
+    }
+
+    assert VintageNetWiFi.configured?(configured)
+    refute VintageNetWiFi.configured?(empty1)
+    refute VintageNetWiFi.configured?(empty2)
+    refute VintageNetWiFi.configured?(%{})
+  end
 end


### PR DESCRIPTION
This is an enhancement adding one convenience function that checks if a WLAN interface is already configured.

This check is used in at least a few Nerves-related projects, such as [Circuits Quickstart] and [Nerves Livebook]. Since the check is related to WLAN, it would be nice to place the decision-making logic for the check here in VintageNetWiFi.

What do you all think? 🤔 

Here are some related commits:
- https://github.com/elixir-circuits/circuits_quickstart/commit/c2608c8be77a917913584f11272179f6f5dfee9b
- https://github.com/nerves-livebook/nerves_livebook/commit/713bff6bcfac333c752bd9ec4718cf5422854926

There can be a better name for the function. `configured?` is kind of ambiguous...

[Circuits Quickstart]: https://github.com/elixir-circuits/circuits_quickstart
[Nerves Livebook]: https://github.com/nerves-livebook/nerves_livebook