### PR TITLE
Revert quick_configure/2 to WPA2, but add option

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ end
 The easiest way to configure WiFi is to using
 `VintageNetWiFi.quick_configure/2`. For example:
 
-```
+```elixir
 iex> VintageNetWiFi.quick_configure("my_access_point", "secret_passphrase")
 :ok
 ```
@@ -55,6 +55,9 @@ network interface works)
 The second easiest way to create WiFi configurations is to use the helper
 functions in `VintageNetWiFi.Cookbook`. Check out the module documentation for
 the various configurations.
+
+See the `VintageNetWiFi.quick_configure/2` documentation for details on WPA3
+support.
 
 ## Advanced usage
 


### PR DESCRIPTION
WPA3 support has been very problematic on some Nerves-supported hardware
to the point where it causes more harm than good. This change reverts
the `quick_configure/2` implementation to use WPA2 when a password is
supplied. If you have hardware that does support WPA3, it's possible to
use the generic WiFi configuration by updating the application
environment:

```
config :vintage_net_wifi, :quick_configure, &VintageNetWiFi.Cookbook.generic/2
```

Here's a short list of hardware support:

* All Raspberry Pi's handle the generic configuration fine, but don't
  support WPA3.
* The BeagleBones with built-in WiFi using the WiLink8 module will
  try to use WPA3 whenever it's available, but fail to connect.
* GRiSP2 won't connect to WPA2 networks with the generic configuration
  even though WPA3 isn't in use at all.
* The NXP 88W8987 appears to work perfectly with the generic
  configuration and connects to both WPA3 and WPA2 APs
