### PR TITLE
Clarify comment regarding usage of VintageNet.get_configuration/1

### DIFF
--- a/lib/vintage_net_wifi.ex
+++ b/lib/vintage_net_wifi.ex
@@ -1067,10 +1067,10 @@ defmodule VintageNetWiFi do
   Returns `false` if the configuration isn't a VintageNetWiFi one or if no
   networks were specified.
 
-  To test an `ifname` has a network configured, run:
+  To test if an `ifname` has a network configured, run:
 
   ```
-  VintageNet.get_configuration() |> network_configured?()
+  VintageNet.get_configuration(ifname) |> network_configured?()
   ```
   """
   @spec network_configured?(map()) :: boolean()


### PR DESCRIPTION
I believe the intention with this comment is to demonstrate pulling the configuration for a specific interface name (string). If someone ran the comment as-is, it won't work because `VintageNet.get_configuration/0` is undefined. 

Updated it to include the ifname in the command and added an `if` for grammar