### PR TITLE
Require Elixir 1.14+

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,12 +5,11 @@ latest: &latest
 
 tags: &tags
   [
-    1.18.3-erlang-27.3-alpine-3.21.3,
+    1.18.3-erlang-27.3.3-alpine-3.21.3,
     1.17.0-erlang-27.0-alpine-3.20.0,
     1.16.2-erlang-26.2.3-alpine-3.19.1,
     1.15.7-erlang-26.1.2-alpine-3.18.4,
-    1.14.5-erlang-25.3.2-alpine-3.18.0,
-    1.13.4-erlang-24.3.4-alpine-3.15.3
+    1.14.5-erlang-25.3.2-alpine-3.18.0
   ]
 
 jobs:

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule VintageNetWiFi.MixProject do
     [
       app: :vintage_net_wifi,
       version: @version,
-      elixir: "~> 1.11",
+      elixir: "~> 1.14",
       elixirc_paths: elixirc_paths(Mix.env()),
       test_coverage: [tool: ExCoveralls],
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
Elixir 1.13 has started not being supported in some libraries. It seems
like it's time to move on and not require PRs to support it.
