### PR TITLE
Fix quick_scan/1 crash on FAIL-BUSY; switch to event-driven wait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@
 
 # Changelog
 
+## Unreleased
+
+* Fixes
+  * `VintageNetWiFi.quick_scan/1` no longer crashes when `wpa_supplicant`
+    returns `FAIL-BUSY` because another scan is already in flight. It now
+    subscribes to the access-point property and waits for an update event,
+    falling back to whatever the property contains on timeout. As a side
+    effect, the function returns as soon as fresh scan results land instead
+    of always sleeping the full `timeout_ms`.
+
 ## v0.12.8 - 2026-04-08
 
 * Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,16 +5,6 @@
 
 # Changelog
 
-## Unreleased
-
-* Fixes
-  * `VintageNetWiFi.quick_scan/1` no longer crashes when `wpa_supplicant`
-    returns `FAIL-BUSY` because another scan is already in flight. It now
-    subscribes to the access-point property and waits for an update event,
-    falling back to whatever the property contains on timeout. As a side
-    effect, the function returns as soon as fresh scan results land instead
-    of always sleeping the full `timeout_ms`.
-
 ## v0.12.8 - 2026-04-08
 
 * Changes

--- a/lib/vintage_net_wifi.ex
+++ b/lib/vintage_net_wifi.ex
@@ -960,14 +960,35 @@ defmodule VintageNetWiFi do
   easier to manage list of access points for presentation to users.
   """
   @spec quick_scan(non_neg_integer()) :: [AccessPoint.t()]
-  def quick_scan(wait_time_ms \\ 2_000) do
-    :ok = ioctl("wlan0", :scan, [])
+  def quick_scan(timeout_ms \\ 2_000) do
+    property = ["interface", "wlan0", "wifi", "access_points"]
+    :ok = VintageNet.subscribe(property)
 
-    # Wait a little for the access points to come in
-    Process.sleep(wait_time_ms)
+    try do
+      # Trigger a scan. If another scan is already in flight, wpa_supplicant
+      # replies FAIL-BUSY — its results land in the same property so we just
+      # wait for them. Any other ioctl error is non-fatal: we'll fall back to
+      # whatever the property already contains after the timeout.
+      _ = ioctl("wlan0", :scan, [])
 
-    VintageNet.get(["interface", "wlan0", "wifi", "access_points"])
-    |> summarize_access_points()
+      receive do
+        {VintageNet, ^property, _old, access_points, _meta} -> access_points
+      after
+        timeout_ms -> VintageNet.get(property) || []
+      end
+      |> summarize_access_points()
+    after
+      VintageNet.unsubscribe(property)
+      flush_property_messages(property)
+    end
+  end
+
+  defp flush_property_messages(property) do
+    receive do
+      {VintageNet, ^property, _old, _new, _meta} -> flush_property_messages(property)
+    after
+      0 -> :ok
+    end
   end
 
   @doc """

--- a/lib/vintage_net_wifi.ex
+++ b/lib/vintage_net_wifi.ex
@@ -962,13 +962,18 @@ defmodule VintageNetWiFi do
   @spec quick_scan(non_neg_integer()) :: [AccessPoint.t()]
   def quick_scan(timeout_ms \\ 2_000) do
     property = ["interface", "wlan0", "wifi", "access_points"]
-    :ok = VintageNet.subscribe(property)
 
-    try do
-      # Trigger a scan. If another scan is already in flight, wpa_supplicant
-      # replies FAIL-BUSY — its results land in the same property so we just
-      # wait for them. Any other ioctl error is non-fatal: we'll fall back to
-      # whatever the property already contains after the timeout.
+    # Run the subscribe/scan/receive cycle inside a Task so the subscription
+    # and any property-update messages stay contained in the task's mailbox.
+    # When the task exits, the BEAM cleans up, so the caller never sees stray
+    # `{VintageNet, ...}` tuples and there's no manual unsubscribe/flush.
+    Task.async(fn ->
+      VintageNet.subscribe(property)
+
+      # If another scan is already in flight, wpa_supplicant replies FAIL-BUSY
+      # — its results land in the same property so we just wait for them. Any
+      # other ioctl error is non-fatal: we'll fall back to whatever the property
+      # already contains after the timeout.
       _ = ioctl("wlan0", :scan, [])
 
       receive do
@@ -976,19 +981,9 @@ defmodule VintageNetWiFi do
       after
         timeout_ms -> VintageNet.get(property) || []
       end
-      |> summarize_access_points()
-    after
-      VintageNet.unsubscribe(property)
-      flush_property_messages(property)
-    end
-  end
-
-  defp flush_property_messages(property) do
-    receive do
-      {VintageNet, ^property, _old, _new, _meta} -> flush_property_messages(property)
-    after
-      0 -> :ok
-    end
+    end)
+    |> Task.await(timeout_ms + 500)
+    |> summarize_access_points()
   end
 
   @doc """


### PR DESCRIPTION
## Summary

- `quick_scan/1` crashed with `MatchError` whenever `wpa_supplicant` returned `FAIL-BUSY` because another scan was already in flight (`:ok = ioctl(...)` hard match at `lib/vintage_net_wifi.ex:963`).
- Restructured the function around a `Task.async/await` block that subscribes to the `access_points` property, kicks the scan, and waits for an update with a bounded timeout. The concurrent scan in the FAIL-BUSY case publishes to the same property, so we get its results without retrying.
- Side benefit: `quick_scan/1` now returns as soon as fresh results arrive instead of always sleeping the full `timeout_ms`.

## Root cause

`WPASupplicant.handle_call(:scan, …)` (lib/vintage_net_wifi/wpa_supplicant.ex:211-218) correctly turns a `FAIL-BUSY` response into `{:error, "FAIL-BUSY"}`. The convenience function `quick_scan/1` then crashed at `:ok = ioctl(...)`. Conceptually FAIL-BUSY is a no-op for callers — the in-flight scan will populate the same `["interface", ifname, "wifi", "access_points"]` property — so there's no need to retry or wait extra.

## Why the Task wrapper

Subscribing on the caller's process means we'd need a `try/after` to unsubscribe plus a flush helper to drain any stray `{VintageNet, ...}` tuples that landed in the caller's mailbox between the first `receive` and `unsubscribe`. Running the subscribe/scan/receive cycle inside `Task.async/2` keeps all of that contained in the task's mailbox — when the task exits the BEAM tears it down, so the caller (often IEx) never sees stray messages and no manual cleanup is needed.

## Alternatives considered

| # | Approach | Crash on unknown error | Returns on FAIL-BUSY | Adapts to fast scans | API change |
|---|---|---|---|---|---|
| 1 | `case` with whitelisted no-op errors (`:ok`, `FAIL-BUSY` → proceed; other → raise) | Yes | Sleeps then reads | No | None |
| 2 | Lenient — `_ = ioctl(...)`, always read property after sleep | No (silent) | Sleeps then reads | No | None |
| 3 | Return `{:ok, [AccessPoint]} \| {:error, reason}` via `with` | No (error tuple) | Sleeps then reads | No | **Breaking** |
| **4** | **Subscribe → trigger → `receive` with timeout fallback, isolated in a `Task` (this PR)** | **No (silent)** | **Yes (same property)** | **Yes** | **None** |
| 5 | Split low-level `scan/1` (strict) from `quick_scan/1` (convenience) | Configurable | Sleeps then reads | No | Additive (`scan/1`) |

Picked #4 because it both fixes the crash *and* tightens the latency floor for fast scans, with the `Task` wrapper avoiding manual unsubscribe/flush bookkeeping. #2 is the smallest possible diff (a three-character change: `:ok =` → `_ =`) if reviewers prefer minimalism; #5 is the cleanest if we want a proper `scan/1` API alongside.

## Test plan

- [x] `mix test` — 96 passing, no regressions
- [x] `mix credo --strict` — clean
- [x] `mix format --check-formatted`
- [ ] Manual: trigger two scans in quick succession on a Nerves device and confirm the second `quick_scan/1` call no longer crashes
- [ ] Manual: confirm `quick_scan/1` returns early (well under `timeout_ms`) when scans complete quickly
