### PR TITLE
Add Credo.Check.Warning.UnsafeToAtom check

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -9,6 +9,7 @@
         {CredoBinaryPatterns.Check.Consistency.Pattern},
         {Credo.Check.Refactor.MapInto, false},
         {Credo.Check.Warning.LazyLogging, false},
+        {Credo.Check.Warning.UnsafeToAtom, []},
         {Credo.Check.Design.TagFIXME, false},
         {Credo.Check.Design.TagTODO, false},
         {Credo.Check.Readability.LargeNumbers, only_greater_than: 86400},


### PR DESCRIPTION
Enables the `Credo.Check.Warning.UnsafeToAtom` check to catch unsafe atom creation from uncontrolled input.