### PR TITLE
Update HexDoc URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ![vintage net logo](assets/logo.png)
 
 [![Hex version](https://img.shields.io/hexpm/v/vintage_net_wifi.svg "Hex version")](https://hex.pm/packages/vintage_net_wifi)
-[![API docs](https://img.shields.io/hexpm/v/vintage_net_wifi.svg?label=hexdocs "API docs")](https://hexdocs.pm/vintage_net_wifi/VintageNetWiFi.html)
+[![API docs](https://img.shields.io/hexpm/v/vintage_net_wifi.svg?label=hexdocs "API docs")](https://vintage-net-wifi.hexdocs.pm/VintageNetWiFi.html)
 [![CircleCI](https://dl.circleci.com/status-badge/img/gh/nerves-networking/vintage_net_wifi/tree/main.svg?style=svg)](https://dl.circleci.com/status-badge/redirect/gh/nerves-networking/vintage_net_wifi/tree/main)
 [![Coverage Status](https://coveralls.io/repos/github/nerves-networking/vintage_net_wifi/badge.svg)](https://coveralls.io/github/nerves-networking/vintage_net_wifi)
 [![REUSE status](https://api.reuse.software/badge/github.com/nerves-networking/vintage_net_wifi)](https://api.reuse.software/info/github.com/nerves-networking/vintage_net_wifi)


### PR DESCRIPTION
Migrates HexDocs URLs to the 2026 format using hex_url_migrator.

<details>
<summary>⚠️ URL verification warnings from <code>hex_url_migrator --verify</code></summary>

```
❌ Verification failed for https://vintage-net-wifi.hexdocs.pm/VintageNetWiFi.html): Status 404
⚠️ Verification finished: 0 success, 1 failure(s).
```

_Reported by the migrator's verifier. Note that `301`s are typically redirects (the target exists) and a trailing `)` is a markdown-link parsing artifact. Please review before merging._
</details>