### PR TITLE
Add support for the sae_pwe wpa_supplicant option

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,11 @@ The `:vintage_net_wifi` key has the following common fields:
   * 1:  Do passive scans.
 * `:regulatory_domain`: Two character country code. Technology configuration
   will take priority over Application configuration
+* `:sae_pwe` - How the SAE password element is derived for WPA3 networks. See
+  the Debugging section if a WPA3 network rejects authentication.
+  * 0:  Hunting-and-pecking only (default)
+  * 1:  Hash-to-element (H2E) only
+  * 2:  Both hunting-and-pecking and H2E
 * `:networks` - A list of Wi-Fi networks to configure. In client mode,
   VintageNet connects to the first available network in the list. In host mode,
   the list should have one entry with SSID and password information.
@@ -534,3 +539,38 @@ Double check that all of your parameters are set correctly. The `:psk` cannot be
 checked here, so if you suspect that's wrong, double check your `config.exs`.
 The next step is to look at log messages for connection errors. On Nerves
 devices, run `RingLogger.next` at the `IEx` prompt.
+
+### WPA3 network rejects authentication
+
+If a WPA3 (SAE) network stays disconnected with repeated
+`CTRL-EVENT-ASSOC-REJECT status_code=16` events even though the password is
+correct, the AP may be rejecting a mismatch between the SAE method used and the
+capabilities the Wi-Fi driver advertises. Some drivers (e.g. `brcmfmac` on
+Raspberry Pis) advertise hash-to-element (H2E) support on their own, while
+`wpa_supplicant` defaults to the older hunting-and-pecking method. APs with H2E
+enabled reject the inconsistency. If the AP runs hostapd, its log shows:
+
+```text
+SAE: <mac> indicates support for SAE H2E, but did not use it
+```
+
+Fix this by adding `sae_pwe: 2` to the `:vintage_net_wifi` map so that
+`wpa_supplicant` may use either method:
+
+```elixir
+%{
+  type: VintageNetWiFi,
+  vintage_net_wifi: %{
+    sae_pwe: 2,
+    networks: [
+      %{
+        ssid: "my_network_ssid",
+        key_mgmt: :sae,
+        sae_password: "a_password",
+        ieee80211w: 2
+      }
+    ]
+  },
+  ipv4: %{method: :dhcp}
+}
+```

--- a/lib/vintage_net_wifi.ex
+++ b/lib/vintage_net_wifi.ex
@@ -112,6 +112,7 @@ defmodule VintageNetWiFi do
     :bgscan,
     :passive_scan,
     :regulatory_domain,
+    :sae_pwe,
     :user_mpm,
     :root_interface,
     :wpa_supplicant_conf_path,
@@ -455,6 +456,7 @@ defmodule VintageNetWiFi do
       if(Map.get(wifi, :wps, true), do: "wps_cred_processing=1"),
       into_config_string(wifi, :bgscan),
       into_config_string(wifi, :ap_scan),
+      into_config_string(wifi, :sae_pwe),
       into_config_string(wifi, :user_mpm)
     ]
 
@@ -741,6 +743,10 @@ defmodule VintageNetWiFi do
 
   defp wifi_opt_to_config_string(_wifi, :sae_password, value) do
     "sae_password=\"#{value}\""
+  end
+
+  defp wifi_opt_to_config_string(_wifi, :sae_pwe, value) do
+    "sae_pwe=#{value}"
   end
 
   defp wifi_opt_to_config_string(_wifi, :ieee80211w, value) do

--- a/test/vintage_net_wifi_test.exs
+++ b/test/vintage_net_wifi_test.exs
@@ -476,6 +476,29 @@ defmodule VintageNetWiFiTest do
     assert output == VintageNetWiFi.to_raw_config("wlan0", input, default_opts())
   end
 
+  test "sae_pwe is written to the wpa_supplicant configuration" do
+    input = %{
+      type: VintageNetWiFi,
+      vintage_net_wifi: %{
+        sae_pwe: 2,
+        networks: [
+          %{
+            ssid: "testing",
+            sae_password: "hunter2",
+            key_mgmt: :sae,
+            ieee80211w: 2
+          }
+        ]
+      },
+      ipv4: %{method: :dhcp},
+      hostname: "unit_test"
+    }
+
+    config = VintageNetWiFi.to_raw_config("wlan0", input, default_opts())
+    {_path, contents} = hd(config.files)
+    assert contents =~ "sae_pwe=2"
+  end
+
   test "create a mixed WPA2-PSK/WPA3-SAE WiFi configuration" do
     input = %{
       type: VintageNetWiFi,


### PR DESCRIPTION
## Summary

Adds a root-level `sae_pwe` key to the `:vintage_net_wifi` map, written to the global section of the generated wpa_supplicant.conf, plus a Debugging section entry for the WPA3 failure it addresses.

```elixir
vintage_net_wifi: %{sae_pwe: 2, networks: [%{ssid: "...", key_mgmt: :sae, sae_password: "...", ieee80211w: 2}]}
```

## Background

wpa_supplicant only does hunting-and-pecking for SAE password element derivation by default (`sae_pwe=0`). The brcmfmac firmware on Raspberry Pis puts an RSNXE advertising H2E support into the association request on its own, even when the supplicant never enabled H2E.

An AP with H2E enabled then sees a station that claims H2E but didn't use it, treats that as a spec violation and rejects the association. The client just loops on assoc-reject status 16 with no useful detail. If the AP runs hostapd (OpenWrt and most Linux-based APs do), its log shows the actual reason:

```
SAE: <mac> indicates support for SAE H2E, but did not use it
```

Setting `sae_pwe=2` lets the supplicant use H2E when the AP advertises it, fixing the mismatch.

Infineon recommends the same setting for these chips (https://community.infineon.com/t5/Knowledge-Base-Articles/WPA3-SAE-Why-sae-pwe-2-should-be-set-in-wpa-supplicant/ta-p/1101703).

This PR does not change any defaults: the wpa_supplicant docs say their default is likely to change from 0 to 2 once H2E has had more interoperability testing, so the value stays whatever the installed wpa_supplicant decides unless the user sets one. The new Debugging section routes anyone hitting the failure to the fix.

## Testing

Reproduced on a CM4 (brcmfmac, wpa_supplicant 2.11) against a WPA3-only AP with H2E enabled: without `sae_pwe` the connection loops on the rejection above, with `sae_pwe=2` it associates immediately. Includes a test that the option is written to the generated config.