### PR TITLE
Support setting custom WiFi addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ config :vintage_net,
           ]
         },
         ipv4: %{method: :dhcp},
+        # mac_address: "aa:bb:cc:dd:ee:ff" or {SomeModule, :get_mac, []}
       }
     }
   ]
@@ -97,7 +98,10 @@ config :vintage_net,
 
 The `:ipv4` key is handled by `vintage_net` to set the IP address on the
 connection. Most of the time, you'll want to use DHCP to dynamically get an IP
-address.
+address. You can also specify a `:mac_address` key here to set the MAC address.
+The `:mac_address` option is set on the network interface and WPA Supplicant
+options for randomized or network-specific addresses are disabled. See the
+`:mac_addr` and `:mac_value` options for other MAC address configuration.
 
 The `:vintage_net_wifi` key has the following common fields:
 
@@ -118,6 +122,12 @@ The `:vintage_net_wifi` key has the following common fields:
   * 0:  Hunting-and-pecking only (default)
   * 1:  Hash-to-element (H2E) only
   * 2:  Both hunting-and-pecking and H2E
+* `:mac_addr` - Global MAC address policy (0-2)
+  * 0: use permanent MAC address (default)
+  * 1: use random MAC
+  * 2: use random MAC, but maintain OUI
+* `:preassoc_mac_addr` - Global pre-association MAC address policy. Same
+  options as `:mac_addr`
 * `:networks` - A list of Wi-Fi networks to configure. In client mode,
   VintageNet connects to the first available network in the list. In host mode,
   the list should have one entry with SSID and password information.
@@ -153,6 +163,9 @@ The `:vintage_net_wifi` key has the following common fields:
   * `:wps` - Set to `false` to disable WPS functionality. This is required if
     your `wpa_supplicant` is compiled without WPS support since VintageNetWiFi
     sets `wps_cred_processing` by default.
+  * `:mac_addr` - MAC address policy (0-3). `0` - use permanent MAC address,
+    `1` - use random MAC. `2` - use random MAC, but maintain OUI, `3` use `:mac_value`
+  * `:mac_value` - either a MAC address string or an MFArgs
 
 These keys fairly directly map to the keys in the [official
 docs](https://w1.fi/cgit/hostap/plain/wpa_supplicant/wpa_supplicant.conf).

--- a/lib/vintage_net_wifi.ex
+++ b/lib/vintage_net_wifi.ex
@@ -7,6 +7,7 @@
 # SPDX-FileCopyrightText: 2023 Ace Yanagida
 # SPDX-FileCopyrightText: 2023 Jon Carstens
 # SPDX-FileCopyrightText: 2024 Thomas Jack
+# SPDX-FileCopyrightText: 2026 Eliel A. Gordon
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -19,6 +20,9 @@ defmodule VintageNetWiFi do
 
   * `:vintage_net_wifi` - WiFi options
   * `:ipv4` - IPv4 options. See VintageNet.IP.IPv4Config.
+  * `:mac_address` - A MAC address string or an MFArgs tuple. VintageNetWiFi
+    passes the MAC address to the `wpa_supplicant`. If an MFArgs tuple is passed,
+    VintageNetWiFi will `apply` it and use the return value as the address.
 
   To scan for WiFi networks it's sufficient to use an empty configuration and call
   the `VintageNet.scan("wlan0")`:
@@ -26,7 +30,6 @@ defmodule VintageNetWiFi do
   ```elixir
   %{type: VintageNetWiFi}
   ```
-
 
   Here's a typical configuration for connecting to a WPA2-protected Wi-Fi network:
 
@@ -81,6 +84,7 @@ defmodule VintageNetWiFi do
   alias VintageNet.IP.IPv4Config
   alias VintageNetWiFi.AccessPoint
   alias VintageNetWiFi.Cookbook
+  alias VintageNetWiFi.MacAddress
   alias VintageNetWiFi.WPA2
   alias VintageNetWiFi.WPASupplicant
 
@@ -99,6 +103,8 @@ defmodule VintageNetWiFi do
     :priority,
     :scan_ssid,
     :frequency,
+    :mac_addr,
+    :mac_value,
     :mesh_hwmp_rootmode,
     :mesh_gate_announcements,
     :ieee80211w,
@@ -108,6 +114,9 @@ defmodule VintageNetWiFi do
 
   @root_level_keys [
     :ap_scan,
+    :mac_addr,
+    :rand_addr_lifetime,
+    :preassoc_mac_addr,
     :networks,
     :bgscan,
     :passive_scan,
@@ -126,10 +135,28 @@ defmodule VintageNetWiFi do
   def normalize(%{type: __MODULE__} = config) do
     config
     |> normalize_wifi()
+    |> normalize_mac_address()
     |> IPv4Config.normalize()
     |> DhcpdConfig.normalize()
     |> DnsdConfig.normalize()
   end
+
+  # This must be called after normalize_wifi
+  defp normalize_mac_address(%{mac_address: mac_address} = config) do
+    if MacAddress.valid?(mac_address) or mfargs?(mac_address) do
+      # When :mac_address is set, suppress wpa_supplicant MAC randomization so
+      # it doesn't override the address set in up_cmds at scan/association time.
+      new_wifi = Map.merge(config.vintage_net_wifi, %{mac_addr: 0, preassoc_mac_addr: 0})
+      %{config | vintage_net_wifi: new_wifi}
+    else
+      raise ArgumentError, "Invalid MAC address #{inspect(mac_address)}"
+    end
+  end
+
+  defp normalize_mac_address(config), do: config
+
+  defp mfargs?({m, f, a}) when is_atom(m) and is_atom(f) and is_list(a), do: true
+  defp mfargs?(_), do: false
 
   defp normalize_wifi(%{vintage_net_wifi: %{wpa_supplicant_conf: conf}} = config) do
     %{config | vintage_net_wifi: %{wpa_supplicant_conf: conf}}
@@ -145,9 +172,10 @@ defmodule VintageNetWiFi do
     %{config | vintage_net_wifi: new_wifi}
   end
 
-  defp normalize_wifi(_config) do
-    # If wifi isn't configured, then only scanning is allowed.
-    %{type: __MODULE__, vintage_net_wifi: %{networks: []}, ipv4: %{method: :disabled}}
+  defp normalize_wifi(config) do
+    # If wifi isn't configured, then make it explicit that there are no networks
+    # and only scanning is allowed.
+    Map.merge(config, %{vintage_net_wifi: %{networks: []}, ipv4: %{method: :disabled}})
   end
 
   defp normalize_first_network(%{ssid: ssid} = wifi) do
@@ -410,10 +438,49 @@ defmodule VintageNetWiFi do
         {WPASupplicant, wpa_supplicant_options}
       ]
     }
+    |> add_mac_address_config(normalized_config)
     |> IPv4Config.add_config(normalized_config, opts)
     |> DhcpdConfig.add_config(normalized_config, opts)
     |> DnsdConfig.add_config(normalized_config, opts)
   end
+
+  defp add_mac_address_config(raw_config, %{mac_address: mac_address}) do
+    resolved_mac = resolve_mac(mac_address)
+
+    if MacAddress.valid?(resolved_mac) do
+      Logger.info(
+        "vintage_net_wifi: setting #{raw_config.ifname} MAC to #{resolved_mac}; forcing mac_addr=0/preassoc_mac_addr=0 in wpa_supplicant.conf"
+      )
+
+      # Bring the interface down before changing the MAC. Some WiFi drivers
+      # reject address changes while the interface is up. IPv4Config.add_config
+      # appends `ip link set <ifname> up` afterwards, and the WPASupplicant
+      # child_spec only starts after up_cmds run, so the supplicant sees the
+      # new MAC.
+      new_up_cmds =
+        raw_config.up_cmds ++
+          [
+            {:run_ignore_errors, "ip", ["link", "set", raw_config.ifname, "down"]},
+            {:run, "ip", ["link", "set", raw_config.ifname, "address", resolved_mac]}
+          ]
+
+      %{raw_config | up_cmds: new_up_cmds}
+    else
+      Logger.warning("vintage_net_wifi: ignoring invalid MAC address '#{inspect(resolved_mac)}'")
+
+      raw_config
+    end
+  end
+
+  defp add_mac_address_config(raw_config, _config), do: raw_config
+
+  defp resolve_mac({m, f, args}) do
+    apply(m, f, args)
+  rescue
+    e -> {:error, e}
+  end
+
+  defp resolve_mac(mac_address), do: mac_address
 
   @impl VintageNet.Technology
   def ioctl(ifname, :scan, _args) do
@@ -456,6 +523,10 @@ defmodule VintageNetWiFi do
       if(Map.get(wifi, :wps, true), do: "wps_cred_processing=1"),
       into_config_string(wifi, :bgscan),
       into_config_string(wifi, :ap_scan),
+      into_config_string(wifi, :mac_addr),
+      into_config_string(wifi, :mac_value),
+      into_config_string(wifi, :rand_addr_lifetime),
+      into_config_string(wifi, :preassoc_mac_addr),
       into_config_string(wifi, :sae_pwe),
       into_config_string(wifi, :user_mpm)
     ]
@@ -512,6 +583,8 @@ defmodule VintageNetWiFi do
       into_config_string(wifi, :mode),
       into_config_string(wifi, :frequency),
       into_config_string(wifi, :ieee80211w),
+      into_config_string(wifi, :mac_addr),
+      into_config_string(wifi, :mac_value),
 
       # WPA-PSK settings
       into_config_string(wifi, :psk),
@@ -611,6 +684,26 @@ defmodule VintageNetWiFi do
 
   defp wifi_opt_to_config_string(_wifi, :ap_scan, value) do
     "ap_scan=#{value}"
+  end
+
+  defp wifi_opt_to_config_string(_wifi, :mac_addr, value) do
+    "mac_addr=#{value}"
+  end
+
+  defp wifi_opt_to_config_string(_wifi, :mac_value, value) when is_binary(value) do
+    "mac_value=#{value}"
+  end
+
+  defp wifi_opt_to_config_string(_wifi, :mac_value, {m, f, a}) do
+    "mac_value=#{apply(m, f, a)}"
+  end
+
+  defp wifi_opt_to_config_string(_wifi, :rand_addr_lifetime, value) do
+    "rand_addr_lifetime=#{value}"
+  end
+
+  defp wifi_opt_to_config_string(_wifi, :preassoc_mac_addr, value) do
+    "preassoc_mac_addr=#{value}"
   end
 
   defp wifi_opt_to_config_string(_wifi, :scan_ssid, value) do

--- a/lib/vintage_net_wifi/mac_address.ex
+++ b/lib/vintage_net_wifi/mac_address.ex
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: 2021 Frank Hunleth
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+defmodule VintageNetWiFi.MacAddress do
+  @moduledoc """
+  MAC Address utilities
+  """
+
+  @typedoc """
+  A MAC address is a string of the form "aa:bb:cc:dd:ee:ff"
+  """
+  @type t() :: <<_::136>>
+
+  @doc """
+  Return true if this is a valid MAC address
+  """
+  @spec valid?(any()) :: boolean()
+  # credo:disable-for-next-line Credo.Check.Refactor.CyclomaticComplexity
+  def valid?(<<a, b, ?:, c, d, ?:, e, f, ?:, g, h, ?:, i, j, ?:, k, l>>) do
+    valid_hex?(a) and
+      valid_hex?(b) and
+      valid_hex?(c) and
+      valid_hex?(d) and
+      valid_hex?(e) and
+      valid_hex?(f) and
+      valid_hex?(g) and
+      valid_hex?(h) and
+      valid_hex?(i) and
+      valid_hex?(j) and
+      valid_hex?(k) and
+      valid_hex?(l)
+  end
+
+  def valid?(_), do: false
+
+  defp valid_hex?(a)
+       when a in [
+              ?0,
+              ?1,
+              ?2,
+              ?3,
+              ?4,
+              ?5,
+              ?6,
+              ?7,
+              ?8,
+              ?9,
+              ?a,
+              ?A,
+              ?b,
+              ?B,
+              ?c,
+              ?C,
+              ?d,
+              ?D,
+              ?e,
+              ?E,
+              ?f,
+              ?F
+            ],
+       do: true
+
+  defp valid_hex?(_), do: false
+end

--- a/test/vintage_net_wifi/mac_address_test.exs
+++ b/test/vintage_net_wifi/mac_address_test.exs
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: 2026 Eliel A. Gordon
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+defmodule VintageNetWiFi.MacAddressTest do
+  use ExUnit.Case
+  alias VintageNetWiFi.MacAddress
+
+  test "valid? accepts well-formed MAC addresses" do
+    assert MacAddress.valid?("aa:bb:cc:dd:ee:ff")
+    assert MacAddress.valid?("AA:BB:CC:DD:EE:FF")
+    assert MacAddress.valid?("00:11:22:33:44:55")
+    assert MacAddress.valid?("01:23:45:67:89:Ab")
+  end
+
+  test "valid? rejects malformed MAC addresses" do
+    refute MacAddress.valid?("")
+    refute MacAddress.valid?("aa:bb:cc:dd:ee")
+    refute MacAddress.valid?("aa:bb:cc:dd:ee:ff:00")
+    refute MacAddress.valid?("aa-bb-cc-dd-ee-ff")
+    refute MacAddress.valid?("zz:bb:cc:dd:ee:ff")
+    refute MacAddress.valid?("a:bb:cc:dd:ee:ff")
+    refute MacAddress.valid?(:not_a_string)
+    refute MacAddress.valid?(nil)
+    refute MacAddress.valid?(123)
+  end
+end

--- a/test/vintage_net_wifi_test.exs
+++ b/test/vintage_net_wifi_test.exs
@@ -4,6 +4,7 @@
 # SPDX-FileCopyrightText: 2023 Ace Yanagida
 # SPDX-FileCopyrightText: 2023 Jon Carstens
 # SPDX-FileCopyrightText: 2024 Masatoshi Nishiguchi
+# SPDX-FileCopyrightText: 2026 Eliel A. Gordon
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -2724,6 +2725,103 @@ defmodule VintageNetWiFiTest do
     refute VintageNetWiFi.network_configured?(empty1)
     refute VintageNetWiFi.network_configured?(empty2)
     refute VintageNetWiFi.network_configured?(%{})
+  end
+
+  test "setting mac_address adds an ip link command and locks supplicant randomization" do
+    input = %{
+      type: VintageNetWiFi,
+      mac_address: "aa:bb:cc:dd:ee:ff",
+      vintage_net_wifi: %{
+        networks: [
+          %{
+            ssid: "guest",
+            key_mgmt: :none
+          }
+        ]
+      },
+      ipv4: %{method: :dhcp},
+      hostname: "unit_test"
+    }
+
+    raw_config = VintageNetWiFi.to_raw_config("wlan0", input, default_opts())
+
+    assert raw_config.up_cmds == [
+             {:run_ignore_errors, "ip", ["link", "set", "wlan0", "down"]},
+             {:run, "ip", ["link", "set", "wlan0", "address", "aa:bb:cc:dd:ee:ff"]},
+             {:run, "ip", ["link", "set", "wlan0", "up"]}
+           ]
+
+    [{_path, contents}] = raw_config.files
+
+    assert contents == """
+           ctrl_interface=/tmp/vintage_net/wpa_supplicant
+           country=00
+           wps_cred_processing=1
+           mac_addr=0
+           preassoc_mac_addr=0
+           network={
+           ssid="guest"
+           key_mgmt=NONE
+           mode=0
+           }
+           """
+  end
+
+  test "mac_address accepts an MFArgs tuple resolved at apply time" do
+    input = %{
+      type: VintageNetWiFi,
+      mac_address: {String, :downcase, ["AA:BB:CC:DD:EE:FF"]},
+      vintage_net_wifi: %{
+        networks: [%{ssid: "guest", key_mgmt: :none}]
+      },
+      ipv4: %{method: :dhcp},
+      hostname: "unit_test"
+    }
+
+    raw_config = VintageNetWiFi.to_raw_config("wlan0", input, default_opts())
+
+    assert {:run, "ip", ["link", "set", "wlan0", "address", "aa:bb:cc:dd:ee:ff"]} in raw_config.up_cmds
+  end
+
+  test "mac_address survives normalization in scan-only mode" do
+    input = %{type: VintageNetWiFi, mac_address: "aa:bb:cc:dd:ee:ff"}
+
+    normalized = VintageNetWiFi.normalize(input)
+
+    assert normalized.mac_address == "aa:bb:cc:dd:ee:ff"
+
+    raw_config = VintageNetWiFi.to_raw_config("wlan0", input, default_opts())
+
+    assert {:run, "ip", ["link", "set", "wlan0", "address", "aa:bb:cc:dd:ee:ff"]} in raw_config.up_cmds
+  end
+
+  test "invalid mac_address raises during normalization" do
+    assert_raise ArgumentError, ~r/Invalid MAC address/, fn ->
+      VintageNetWiFi.normalize(%{type: VintageNetWiFi, mac_address: "not a mac"})
+    end
+  end
+
+  test "an unresolvable MFArgs MAC is logged and ignored" do
+    input = %{
+      type: VintageNetWiFi,
+      mac_address: {Kernel, :inspect, [:not_a_mac]},
+      vintage_net_wifi: %{networks: [%{ssid: "guest", key_mgmt: :none}]},
+      ipv4: %{method: :dhcp},
+      hostname: "unit_test"
+    }
+
+    log =
+      capture_log(fn ->
+        raw_config = VintageNetWiFi.to_raw_config("wlan0", input, default_opts())
+
+        # No ip link set address command was added
+        refute Enum.any?(raw_config.up_cmds, fn
+                 {:run, "ip", ["link", "set", _, "address", _]} -> true
+                 _ -> false
+               end)
+      end)
+
+    assert log =~ "ignoring invalid MAC address"
   end
 
   test "generating QR strings" do


### PR DESCRIPTION
This adds the `:mac_address` option in a similar way to VintageNetEthernet so that the MAC address can be set. It also exposes many of the WPA Supplicant options so that supplicant-driven MAC randomization can be enabled.
